### PR TITLE
fix: update simulate cmd to take assembled peers info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .PHONY: all
 all: build check-fmt check-clippy test
 
-
 .PHONY: test
 test:
 	# Test with default features

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -2,9 +2,8 @@
 #![deny(missing_docs)]
 
 mod bootstrap;
-// TODO re-add these once the operator understands simulations
-//mod scenario;
-//mod simulate;
+mod scenario;
+mod simulate;
 mod utils;
 
 use keramik_common::telemetry;
@@ -15,8 +14,7 @@ use opentelemetry::{global, KeyValue};
 use opentelemetry::{global::shutdown_tracer_provider, Context};
 use tracing::info;
 
-//use crate::{bootstrap::bootstrap, simulate::simulate};
-use crate::bootstrap::bootstrap;
+use crate::{bootstrap::bootstrap, simulate::simulate};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -38,7 +36,7 @@ pub enum Command {
     /// Bootstrap peers in the network
     Bootstrap(bootstrap::Opts),
     /// Simulate a load scenario against the network
-    //Simulate(simulate::Opts),
+    Simulate(simulate::Opts),
     /// Do nothing and exit
     Noop,
 }
@@ -47,7 +45,7 @@ impl Command {
     fn name(&self) -> &'static str {
         match self {
             Command::Bootstrap(_) => "bootstrap",
-            //Command::Simulate(_) => "simulate",
+            Command::Simulate(_) => "simulate",
             Command::Noop => "noop",
         }
     }
@@ -72,7 +70,7 @@ async fn main() -> Result<()> {
     info!(?args.command, ?args.otlp_endpoint, "starting runner");
     match args.command {
         Command::Bootstrap(opts) => bootstrap(opts).await?,
-        //Command::Simulate(opts) => simulate(opts).await?,
+        Command::Simulate(opts) => simulate(opts).await?,
         Command::Noop => {}
     }
 

--- a/runner/src/scenario/ipfs_block_fetch.rs
+++ b/runner/src/scenario/ipfs_block_fetch.rs
@@ -60,10 +60,7 @@ async fn put(topo: Topology, user: &mut GooseUser) -> TransactionResult {
     let (cid, data) = user_data(user.weighted_users_index, topo);
     println!(
         "put id: {} user: {} nonce: {} cid: {}",
-        topo.target_worker,
-        user.weighted_users_index,
-        topo.nonce,
-        cid.to_string(),
+        topo.target_worker, user.weighted_users_index, topo.nonce, cid,
     );
 
     // Build a Reqwest RequestBuilder object.
@@ -97,15 +94,13 @@ async fn get(mut topo: Topology, user: &mut GooseUser) -> TransactionResult {
     let (cid, _data) = user_data(user.weighted_users_index, topo);
     println!(
         "get id: {} user: {} cid: {}",
-        topo.target_worker,
-        user.weighted_users_index,
-        cid.to_string(),
+        topo.target_worker, user.weighted_users_index, cid,
     );
 
     let request_builder = user
         .get_request_builder(
             &GooseMethod::Post,
-            format!("/api/v0/dag/get?arg={}", cid.to_string()).as_str(),
+            format!("/api/v0/dag/get?arg={}", cid).as_str(),
         )?
         .timeout(Duration::from_secs(5));
 
@@ -127,15 +122,13 @@ async fn check(topo: Topology, user: &mut GooseUser) -> TransactionResult {
     let (cid, data) = user_data(user.weighted_users_index, topo);
     println!(
         "stop id: {} user: {} cid: {}",
-        topo.target_worker,
-        user.weighted_users_index,
-        cid.to_string(),
+        topo.target_worker, user.weighted_users_index, cid,
     );
 
     let request_builder = user
         .get_request_builder(
             &GooseMethod::Post,
-            format!("/api/v0/dag/get?arg={}", cid.to_string()).as_str(),
+            format!("/api/v0/dag/get?arg={}", cid).as_str(),
         )?
         .timeout(Duration::from_secs(15));
 


### PR DESCRIPTION
Prior to this change the simulate command assumed the peer RPC address based on the peer index. Now with this change a JSON encoding of peers and their address must be specified. This enables the simulate command to work well with the operator.