### PR TITLE
fix: add tests for operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,6 +777,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +895,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "diffy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e616e59155c92257e84970156f506287853355f58cd4a6eb167385722c32b790"
+dependencies = [
+ "nu-ansi-term",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +948,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dissimilar"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "210ec60ae7d710bed8683e333e9d2855a8a56a3e9892b38bad3bb0d4d29b0d5e"
 
 [[package]]
 name = "downcast-rs"
@@ -976,6 +1007,16 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "expect-test"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d9eafeadd538e68fb28016364c9732d78e420b9ff8853fa5e4058861e9f8d3"
+dependencies = [
+ "dissimilar",
+ "once_cell",
 ]
 
 [[package]]
@@ -1591,9 +1632,14 @@ name = "keramik-operator"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
+ "diffy",
+ "expect-test",
  "futures",
  "hex",
+ "http",
+ "hyper",
  "k8s-openapi",
  "keramik-common",
  "kube",
@@ -1612,10 +1658,12 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
+ "tower-test",
  "tracing",
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "unimock",
 ]
 
 [[package]]
@@ -2318,6 +2366,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,6 +2477,18 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
+]
 
 [[package]]
 name = "prettyplease"
@@ -3287,6 +3356,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-test"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,6 +3510,20 @@ name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tower-test"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4546773ffeab9e4ea02b8872faa49bb616a80a7da66afc2f32688943f97efa7"
+dependencies = [
+ "futures-util",
+ "pin-project",
+ "tokio",
+ "tokio-test",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "tracing"
@@ -3623,6 +3719,28 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unimock"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa46b37ccb0341a256f583def2628c2d00158c37dac5f4ede95f4fa0dcf01ce6"
+dependencies = [
+ "once_cell",
+ "pretty_assertions",
+ "unimock_macros",
+]
+
+[[package]]
+name = "unimock_macros"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c574c9b375e8e4d35027aee2959c7b4b384ca9d94e3d9a7fa50640b8b0d4ff16"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -3990,6 +4108,12 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -1,123 +1,58 @@
-bench = []
-test = []
-example = []
 
 [[bin]]
 path = "src/crdgen.rs"
 name = "crdgen"
-test = true
-doctest = true
-bench = true
-doc = false
-plugin = false
-proc-macro = false
-harness = true
-required-features = []
 
 [[bin]]
 path = "src/main.rs"
 name = "keramik-operator"
-test = true
-doctest = true
-bench = true
-doc = true
-plugin = false
-proc-macro = false
-harness = true
-required-features = []
 
 [package]
 name = "keramik-operator"
 edition = "2021"
 version = "0.0.1"
 description = "K8s operator binary for automating Ceramic networks"
-autobins = true
-autoexamples = true
-autotests = true
-autobenches = true
 
 [dependencies]
+async-trait = "0.1.68"
 futures = "0.3"
 hex = "0.4.3"
 once_cell = "1.17.1"
 rand = "0.8.5"
 serde_yaml = "0.9.21"
 thiserror = "1"
+anyhow.workspace = true
+clap.workspace = true
+k8s-openapi = { version = "0.18", features = [
+    "v1_26",
+    "schemars",
+], default-features = false }
+keramik-common.workspace = true
+kube = { version = "0.82", features = [
+    "derive",
+    "runtime",
+], default-features = true }
+multiaddr.workspace = true
+multibase.workspace = true
+multihash.workspace = true
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+reqwest.workspace = true
+schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tonic.workspace = true
+tracing.workspace = true
+tracing-log.workspace = true
+tracing-opentelemetry.workspace = true
+tracing-subscriber.workspace = true
+unimock = "0.4"
 
-[dependencies.anyhow]
-workspace = true
 
-[dependencies.clap]
-workspace = true
-
-[dependencies.k8s-openapi]
-version = "0.18"
-features = ["v1_26", "schemars"]
-default-features = false
-
-[dependencies.keramik-common]
-workspace = true
-
-[dependencies.kube]
-version = "0.82"
-features = ["derive", "runtime"]
-default-features = true
-
-[dependencies.multiaddr]
-workspace = true
-
-[dependencies.multibase]
-workspace = true
-
-[dependencies.multihash]
-workspace = true
-
-[dependencies.opentelemetry]
-workspace = true
-
-[dependencies.opentelemetry-otlp]
-workspace = true
-
-[dependencies.reqwest]
-workspace = true
-
-[dependencies.schemars]
-workspace = true
-
-[dependencies.serde]
-workspace = true
-
-[dependencies.serde_json]
-workspace = true
-
-[dependencies.tokio]
-workspace = true
-
-[dependencies.tonic]
-workspace = true
-
-[dependencies.tracing]
-workspace = true
-
-[dependencies.tracing-log]
-workspace = true
-
-[dependencies.tracing-opentelemetry]
-workspace = true
-
-[dependencies.tracing-subscriber]
-workspace = true
-
-[lib]
-path = "src/lib.rs"
-name = "keramik_operator"
-test = true
-doctest = true
-bench = true
-doc = true
-plugin = false
-proc-macro = false
-harness = true
-edition = "2021"
-required-features = []
-crate-type = ["rlib"]
+[dev-dependencies]
+diffy = "0.3.0"
+expect-test = "1.4.1"
+http = "0.2.9"
+hyper = "0.14.26"
+tower-test = "0.4.0"

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -788,7 +788,7 @@ mod test {
                    "kind": "ConfigMap",
                    "data": {
             -        "peers.json": "[]"
-            +        "peers.json": "[{\"index\":0,\"peer_id\":\"peer_id_0\",\"rpc_addr\":\"http://peer0\",\"p2p_addrs\":[\"/ip4/10.0.0.1/tcp/4001/p2p/peer_id_0\"]},{\"index\":1,\"peer_id\":\"peer_id_1\",\"rpc_addr\":\"http://peer1\",\"p2p_addrs\":[\"/ip4/10.0.0.2/tcp/4001/p2p/peer_id_1\"]}]"
+            +        "peers.json": "[{\"index\":0,\"peerId\":\"peer_id_0\",\"rpcAddr\":\"http://peer0\",\"p2pAddrs\":[\"/ip4/10.0.0.1/tcp/4001/p2p/peer_id_0\"]},{\"index\":1,\"peerId\":\"peer_id_1\",\"rpcAddr\":\"http://peer1\",\"p2pAddrs\":[\"/ip4/10.0.0.2/tcp/4001/p2p/peer_id_1\"]}]"
                    },
                    "metadata": {
                      "labels": {
@@ -801,26 +801,26 @@ mod test {
                  body: {
                    "status": {
             -        "replicas": 0,
-            -        "ready_replicas": 0,
+            -        "readyReplicas": 0,
             -        "namespace": null,
             -        "peers": []
             +        "replicas": 2,
-            +        "ready_replicas": 2,
+            +        "readyReplicas": 2,
             +        "namespace": "keramik-test",
             +        "peers": [
             +          {
             +            "index": 0,
-            +            "peer_id": "peer_id_0",
-            +            "rpc_addr": "http://peer0",
-            +            "p2p_addrs": [
+            +            "peerId": "peer_id_0",
+            +            "rpcAddr": "http://peer0",
+            +            "p2pAddrs": [
             +              "/ip4/10.0.0.1/tcp/4001/p2p/peer_id_0"
             +            ]
             +          },
             +          {
             +            "index": 1,
-            +            "peer_id": "peer_id_1",
-            +            "rpc_addr": "http://peer1",
-            +            "p2p_addrs": [
+            +            "peerId": "peer_id_1",
+            +            "rpcAddr": "http://peer1",
+            +            "p2pAddrs": [
             +              "/ip4/10.0.0.2/tcp/4001/p2p/peer_id_1"
             +            ]
             +          }

--- a/operator/src/network/mod.rs
+++ b/operator/src/network/mod.rs
@@ -6,6 +6,12 @@ pub(crate) mod controller;
 pub(crate) mod peers;
 pub(crate) mod utils;
 
+#[cfg(test)]
+pub mod stub;
+// Expose Context for testing
+#[cfg(test)]
+pub use controller::Context;
+
 pub use bootstrap::BootstrapSpec;
 pub use ceramic::CeramicSpec;
 pub use controller::run;
@@ -16,7 +22,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Primary CRD for creating and managing a Ceramic network.
-#[derive(CustomResource, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[derive(CustomResource, Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
 #[kube(
     group = "keramik.3box.io",
     version = "v1",

--- a/operator/src/network/stub.rs
+++ b/operator/src/network/stub.rs
@@ -1,0 +1,472 @@
+//! Helper methods only available for tests
+
+use anyhow::Result;
+use expect_test::{expect_file, Expect, ExpectFile};
+use hyper::{body::to_bytes, Body};
+use k8s_openapi::api::core::v1::Secret;
+use kube::Client;
+use reqwest::header::HeaderMap;
+use serde::Serialize;
+use std::sync::Arc;
+
+use crate::network::{utils::RpcClient, Context, Network, NetworkSpec, NetworkStatus};
+
+// We wrap tower_test::mock::Handle
+type ApiServerHandle = tower_test::mock::Handle<http::Request<Body>, http::Response<Body>>;
+pub struct ApiServerVerifier(ApiServerHandle);
+
+// Add tests specific implementation to the Network
+impl Network {
+    /// A normal test network
+    pub fn test() -> Self {
+        Network::new("test", NetworkSpec::default())
+    }
+    /// Modify a network to have an expected spec
+    pub fn with_spec(self, spec: NetworkSpec) -> Self {
+        Self { spec, ..self }
+    }
+    /// Modify a network to have an expected status
+    pub fn with_status(self, status: NetworkStatus) -> Self {
+        Self {
+            status: Some(status),
+            ..self
+        }
+    }
+}
+// Add test specific implementation to the Context
+impl<R> Context<R>
+where
+    R: RpcClient,
+{
+    // Create a test context with a mocked kube and rpc clients
+    pub fn test(mock_rpc_client: R) -> (Arc<Self>, ApiServerVerifier) {
+        let (mock_service, handle) =
+            tower_test::mock::pair::<http::Request<Body>, http::Response<Body>>();
+        let mock_k_client = Client::new(mock_service, "default");
+        let ctx = Self {
+            k_client: mock_k_client,
+            rpc_client: mock_rpc_client,
+        };
+        (Arc::new(ctx), ApiServerVerifier(handle))
+    }
+}
+
+/// Stub of expected requests during reconciliation.
+///
+/// ```no_run
+/// let mut stub = Stub::default();
+/// // Patch the cas_service expected value.
+/// // This patches the expected request the controller will make from its default.
+/// // Default expecations are found in `./testdata/default_stubs`.
+/// // Use `UPDATE_EXPECT=1 cargo test` to update all expect! including this patch.
+/// stub.cas_service.patch(expect![[r#"..."#]]);
+/// ```
+#[derive(Debug)]
+pub struct Stub {
+    network: Network,
+    pub namespace: ExpectPatch<ExpectFile>,
+    pub status: ExpectPatch<ExpectFile>,
+    pub postgres_auth_secret: (ExpectPatch<ExpectFile>, Secret),
+    pub ceramic_admin_secret: (ExpectPatch<ExpectFile>, Secret),
+    pub ceramic_stateful_set: ExpectPatch<ExpectFile>,
+    pub keramik_peers_configmap: ExpectPatch<ExpectFile>,
+    pub cas_service: ExpectPatch<ExpectFile>,
+    pub cas_ipfs_service: ExpectPatch<ExpectFile>,
+    pub ganache_service: ExpectPatch<ExpectFile>,
+    pub cas_postgres_service: ExpectPatch<ExpectFile>,
+    pub cas_stateful_set: ExpectPatch<ExpectFile>,
+    pub cas_ipfs_stateful_set: ExpectPatch<ExpectFile>,
+    pub ganache_stateful_set: ExpectPatch<ExpectFile>,
+    pub cas_postgres_stateful_set: ExpectPatch<ExpectFile>,
+    pub ceramic_init_configmap: ExpectPatch<ExpectFile>,
+    pub ceramic_service: ExpectPatch<ExpectFile>,
+    pub bootstrap_job: Option<ExpectFile>,
+}
+
+impl Stub {
+    pub fn with_network(self, network: Network) -> Self {
+        Self { network, ..self }
+    }
+}
+
+impl Default for Stub {
+    fn default() -> Self {
+        Self {
+            network: Network::test(),
+            namespace: expect_file!["./testdata/default_stubs/namespace"].into(),
+            status: expect_file!["./testdata/default_stubs/status"].into(),
+            postgres_auth_secret: (
+                expect_file!["./testdata/default_stubs/postgres_auth_secret"].into(),
+                k8s_openapi::api::core::v1::Secret {
+                    metadata: kube::core::ObjectMeta {
+                        name: Some("postgres-auth".to_owned()),
+                        labels: super::controller::managed_labels(),
+                        ..kube::core::ObjectMeta::default()
+                    },
+                    ..Default::default()
+                },
+            ),
+            ceramic_admin_secret: (
+                expect_file!["./testdata/default_stubs/ceramic_admin_secret"].into(),
+                k8s_openapi::api::core::v1::Secret {
+                    metadata: kube::core::ObjectMeta {
+                        name: Some("ceramic-admin".to_owned()),
+                        labels: super::controller::managed_labels(),
+                        ..kube::core::ObjectMeta::default()
+                    },
+                    ..Default::default()
+                },
+            ),
+            ceramic_stateful_set: expect_file!["./testdata/default_stubs/ceramic_stateful_set"]
+                .into(),
+            keramik_peers_configmap: expect_file![
+                "./testdata/default_stubs/keramik_peers_configmap"
+            ]
+            .into(),
+            cas_service: expect_file!["./testdata/default_stubs/cas_service"].into(),
+            cas_ipfs_service: expect_file!["./testdata/default_stubs/cas_ipfs_service"].into(),
+            ganache_service: expect_file!["./testdata/default_stubs/ganache_service"].into(),
+            cas_postgres_service: expect_file!["./testdata/default_stubs/cas_postgres_service"]
+                .into(),
+            cas_stateful_set: expect_file!["./testdata/default_stubs/cas_stateful_set"].into(),
+            cas_ipfs_stateful_set: expect_file!["./testdata/default_stubs/cas_ipfs_stateful_set"]
+                .into(),
+            ganache_stateful_set: expect_file!["./testdata/default_stubs/ganache_stateful_set"]
+                .into(),
+            cas_postgres_stateful_set: expect_file![
+                "./testdata/default_stubs/cas_postgres_stateful_set"
+            ]
+            .into(),
+            ceramic_init_configmap: expect_file!["./testdata/default_stubs/ceramic_init_configmap"]
+                .into(),
+            ceramic_service: expect_file!["./testdata/default_stubs/ceramic_service"].into(),
+            bootstrap_job: None,
+        }
+    }
+}
+
+pub async fn timeout_after_1s(handle: tokio::task::JoinHandle<()>) {
+    tokio::time::timeout(std::time::Duration::from_secs(1), handle)
+        .await
+        .expect("timeout on mock apiserver")
+        .expect("stub succeeded")
+}
+
+impl ApiServerVerifier {
+    /// Run a test with the given stub.
+    ///
+    /// NB: If the controller is making more calls than we are handling in the stub,
+    /// you then typically see a `KubeError(Service(Closed(())))` from the reconciler.
+    ///
+    /// You should await the `JoinHandle` (with a timeout) from this function to ensure that the
+    /// stub runs to completion (i.e. all expected calls were responded to),
+    /// using the timeout to catch missing api calls to Kubernetes.
+    pub fn run(mut self, stub: Stub) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            // We need to handle each expected call in sequence
+            self.handle_apply(stub.namespace)
+                .await
+                .expect("namespace should apply");
+            self.handle_request_response(stub.postgres_auth_secret.0, &stub.postgres_auth_secret.1)
+                .await
+                .expect("postgres-auth secret should exist");
+            self.handle_apply(stub.cas_service)
+                .await
+                .expect("cas service should apply");
+            self.handle_apply(stub.cas_ipfs_service)
+                .await
+                .expect("cas-ipfs service should apply");
+            self.handle_apply(stub.ganache_service)
+                .await
+                .expect("ganache service should apply");
+            self.handle_apply(stub.cas_postgres_service)
+                .await
+                .expect("cas-postgres service should apply");
+            self.handle_apply(stub.cas_stateful_set)
+                .await
+                .expect("cas stateful set should apply");
+            self.handle_apply(stub.cas_ipfs_stateful_set)
+                .await
+                .expect("cas-ipfs stateful set should apply");
+            self.handle_apply(stub.ganache_stateful_set)
+                .await
+                .expect("ganache stateful set should apply");
+            self.handle_apply(stub.cas_postgres_stateful_set)
+                .await
+                .expect("cas-postgres stateful set should apply");
+            self.handle_request_response(stub.ceramic_admin_secret.0, &stub.ceramic_admin_secret.1)
+                .await
+                .expect("ceramic-admin secret should exist");
+            self.handle_apply(stub.ceramic_init_configmap)
+                .await
+                .expect("ceramic-init configmap should apply");
+            self.handle_apply(stub.ceramic_service)
+                .await
+                .expect("ceramic service should apply");
+            self.handle_apply(stub.ceramic_stateful_set)
+                .await
+                .expect("ceramic stateful set should apply");
+            self.handle_apply(stub.keramik_peers_configmap)
+                .await
+                .expect("keramik-peers configmap should apply");
+            if let Some(bootstrap_job) = stub.bootstrap_job {
+                self.handle_apply(bootstrap_job)
+                    .await
+                    .expect("bootstrap job should apply");
+            }
+            self.handle_patch_status(stub.status, stub.network.clone())
+                .await
+                .expect("status should patch");
+        })
+    }
+
+    async fn handle_patch_status(
+        &mut self,
+        expected_request: impl Expectation,
+        network: Network,
+    ) -> Result<()> {
+        let (request, send) = self.0.next_request().await.expect("service not called");
+        let request = Request::from_request(request).await?;
+        expected_request.assert_debug_eq(&request);
+
+        let json: serde_json::Value =
+            serde_json::from_str(&request.body.0).expect("status should be JSON");
+
+        let status_json = json.get("status").expect("status object").clone();
+        let status: NetworkStatus =
+            serde_json::from_value(status_json).expect("JSON should be a valid status");
+
+        let network = network.with_status(status);
+        let response = serde_json::to_vec(&network).unwrap();
+        send.send_response(
+            http::Response::builder()
+                .body(Body::from(response))
+                .unwrap(),
+        );
+        Ok(())
+    }
+
+    async fn handle_apply(&mut self, expected_request: impl Expectation) -> Result<()> {
+        let (request, send) = self.0.next_request().await.expect("service not called");
+        let request = Request::from_request(request).await?;
+        expected_request.assert_debug_eq(&request);
+
+        send.send_response(
+            http::Response::builder()
+                .body(Body::from(request.body.0))
+                .unwrap(),
+        );
+        Ok(())
+    }
+    async fn handle_request_response<T>(
+        &mut self,
+        expected_request: impl Expectation,
+        response: &T,
+    ) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let (request, send) = self.0.next_request().await.expect("service not called");
+        let request = Request::from_request(request).await?;
+        expected_request.assert_debug_eq(&request);
+
+        let response = serde_json::to_vec(response).unwrap();
+        send.send_response(
+            http::Response::builder()
+                .body(Body::from(response))
+                .unwrap(),
+        );
+        Ok(())
+    }
+}
+
+// Helper struct to assert the contents of a mock Request.
+// The only purpose of this struct is its debug implementation
+// to be used in expect![[]] calls.
+struct Request {
+    pub method: String,
+    pub uri: String,
+    pub headers: HeaderMap,
+    pub body: Raw,
+}
+
+// Explicit Debug implementation so the fields are not marked as dead code.
+impl std::fmt::Debug for Request {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Request")
+            .field("method", &self.method)
+            .field("uri", &self.uri)
+            .field("headers", &self.headers)
+            .field("body", &self.body)
+            .finish()
+    }
+}
+
+impl Request {
+    async fn from_request(request: http::Request<Body>) -> Result<Self> {
+        let method = request.method().to_string();
+        let uri = request.uri().to_string();
+        let headers = request.headers().clone();
+        let body_bytes = to_bytes(request.into_body()).await?;
+        let body = if !body_bytes.is_empty() {
+            let json: serde_json::Value =
+                serde_json::from_slice(&body_bytes).expect("body should be JSON");
+            Raw(serde_json::to_string_pretty(&json)?)
+        } else {
+            Raw("".to_string())
+        };
+        Ok(Self {
+            method,
+            uri,
+            headers,
+            body,
+        })
+    }
+}
+
+// Raw String the does not escape its value for debugging
+struct Raw(String);
+impl std::fmt::Debug for Raw {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Defines a common interface for asserting an expectation.
+///
+/// The types expect_test::Expect, expect_test::ExpectFile and ExpectPatch all implement this trait.
+trait Expectation {
+    /// Make an assertion about the actual value compared to the expectation.
+    fn assert_debug_eq(&self, actual: &impl std::fmt::Debug);
+}
+
+/// Defines a common interface exposing the expected data for an Expectation.
+///
+/// This allows ExpectPatch to be composed of either Expect or ExpectFile.
+trait ExpectData {
+    /// The data that is expected.
+    fn data(&self) -> String;
+}
+
+/// Wraps an expectation with the ability to patch that expectation.
+///
+/// ```
+/// let mut expect: ExpectPatch<ExpectFile> = expect_file![["path/to/large/test/fixture"]].into();
+/// expect.patch(expect![[r#"
+/// --- original
+/// +++ modified
+/// @@ -1,2 +1,3 @@
+///  Small patch
+///  to the larger
+/// +expectation data
+/// "]];
+/// ```
+///
+/// If you find yourself manually writing the patch text,
+/// instead use `UPDATE_EXPECT=1 cargo test` to update the patch text itself.
+#[derive(Debug)]
+pub struct ExpectPatch<E> {
+    original: E,
+    patch: Option<Expect>,
+}
+
+impl<E> ExpectPatch<E> {
+    pub fn patch(&mut self, patch: Expect) {
+        self.patch = Some(patch)
+    }
+}
+
+impl From<ExpectFile> for ExpectPatch<ExpectFile> {
+    fn from(value: ExpectFile) -> Self {
+        Self {
+            original: value,
+            patch: None,
+        }
+    }
+}
+
+impl From<Expect> for ExpectPatch<Expect> {
+    fn from(value: Expect) -> Self {
+        Self {
+            original: value,
+            patch: None,
+        }
+    }
+}
+
+impl<E> Expectation for ExpectPatch<E>
+where
+    E: ExpectData + Expectation,
+{
+    fn assert_debug_eq(&self, actual: &impl std::fmt::Debug) {
+        if let Some(patch) = &self.patch {
+            let actual = &format!("{:#?}", actual);
+            let original = self.original.data();
+            // Ensure both end in a new line to avoid noisy patch data
+            let original = original.trim().to_owned() + "\n";
+            let actual = actual.trim().to_owned() + "\n";
+            let actual_patch = diffy::create_patch(&original, &actual);
+            patch.assert_eq(&format!("{actual_patch}"));
+        } else {
+            self.original.assert_debug_eq(actual)
+        }
+    }
+}
+
+impl Expectation for Expect {
+    fn assert_debug_eq(&self, actual: &impl std::fmt::Debug) {
+        self.assert_debug_eq(actual)
+    }
+}
+impl ExpectData for Expect {
+    fn data(&self) -> String {
+        self.data().to_owned()
+    }
+}
+
+impl Expectation for ExpectFile {
+    fn assert_debug_eq(&self, actual: &impl std::fmt::Debug) {
+        self.assert_debug_eq(actual)
+    }
+}
+impl ExpectData for ExpectFile {
+    fn data(&self) -> String {
+        // This is taken from the internals of expect_file, maybe we can submit a change to expose
+        // the file contents directly?
+        let path_of_test_file = std::path::Path::new(self.position).parent().unwrap();
+        static WORKSPACE_ROOT: once_cell::sync::OnceCell<std::path::PathBuf> =
+            once_cell::sync::OnceCell::new();
+        let abs_path = WORKSPACE_ROOT
+            .get_or_try_init(|| {
+                // Until https://github.com/rust-lang/cargo/issues/3946 is resolved, this
+                // is set with a hack like https://github.com/rust-lang/cargo/issues/3946#issuecomment-973132993
+                if let Ok(workspace_root) = std::env::var("CARGO_WORKSPACE_DIR") {
+                    return Ok(workspace_root.into());
+                }
+
+                // If a hack isn't used, we use a heuristic to find the "top-level" workspace.
+                // This fails in some cases, see https://github.com/rust-analyzer/expect-test/issues/33
+                let my_manifest = std::env::var("CARGO_MANIFEST_DIR")?;
+                let workspace_root = std::path::Path::new(&my_manifest)
+                    .ancestors()
+                    .filter(|it| it.join("Cargo.toml").exists())
+                    .last()
+                    .unwrap()
+                    .to_path_buf();
+
+                Ok(workspace_root)
+            })
+            .unwrap_or_else(|_: std::env::VarError| {
+                panic!(
+                    "No CARGO_MANIFEST_DIR env var and the path is relative: {}",
+                    path_of_test_file.display()
+                )
+            })
+            .join(path_of_test_file)
+            .join(&self.path);
+
+        std::fs::read_to_string(abs_path)
+            .unwrap_or_default()
+            .replace("\r\n", "\n")
+    }
+}

--- a/operator/src/network/testdata/bootstrap_job_two_peers
+++ b/operator/src/network/testdata/bootstrap_job_two_peers
@@ -1,0 +1,74 @@
+Request {
+    method: "PATCH",
+    uri: "/apis/batch/v1/namespaces/keramik-test/jobs/bootstrap?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "batch/v1",
+      "kind": "Job",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "bootstrap"
+      },
+      "spec": {
+        "backoffLimit": 4,
+        "template": {
+          "spec": {
+            "containers": [
+              {
+                "command": [
+                  "/usr/bin/keramik-runner",
+                  "bootstrap"
+                ],
+                "env": [
+                  {
+                    "name": "RUNNER_OTLP_ENDPOINT",
+                    "value": "http://otel:4317"
+                  },
+                  {
+                    "name": "RUST_LOG",
+                    "value": "info,keramik_runner=debug"
+                  },
+                  {
+                    "name": "BOOTSTRAP_METHOD",
+                    "value": "ring"
+                  },
+                  {
+                    "name": "BOOTSTRAP_N",
+                    "value": "3"
+                  },
+                  {
+                    "name": "BOOTSTRAP_PEERS_PATH",
+                    "value": "/keramik-peers/peers.json"
+                  }
+                ],
+                "image": "public.ecr.aws/r5b3e0r5/3box/keramik-runner",
+                "imagePullPolicy": "Always",
+                "name": "bootstrap",
+                "volumeMounts": [
+                  {
+                    "mountPath": "/keramik-peers",
+                    "name": "keramik-peers"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Never",
+            "volumes": [
+              {
+                "configMap": {
+                  "defaultMode": 493,
+                  "name": "keramik-peers"
+                },
+                "name": "keramik-peers"
+              }
+            ]
+          }
+        }
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/cas_ipfs_service
+++ b/operator/src/network/testdata/default_stubs/cas_ipfs_service
@@ -1,0 +1,32 @@
+Request {
+    method: "PATCH",
+    uri: "/api/v1/namespaces/keramik-test/services/cas-ipfs?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "cas-ipfs"
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "cas-ipfs",
+            "port": 5001,
+            "protocol": "TCP",
+            "targetPort": 5001
+          }
+        ],
+        "selector": {
+          "app": "cas-ipfs"
+        },
+        "type": "ClusterIP"
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/cas_ipfs_stateful_set
+++ b/operator/src/network/testdata/default_stubs/cas_ipfs_stateful_set
@@ -1,0 +1,114 @@
+Request {
+    method: "PATCH",
+    uri: "/apis/apps/v1/namespaces/keramik-test/statefulsets/cas-ipfs?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "apps/v1",
+      "kind": "StatefulSet",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "cas-ipfs"
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app": "cas-ipfs"
+          }
+        },
+        "serviceName": "cas-ipfs",
+        "template": {
+          "metadata": {
+            "labels": {
+              "app": "cas-ipfs"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "command": [
+                  "/usr/bin/ceramic-one",
+                  "daemon",
+                  "--store-dir",
+                  "/data/ipfs",
+                  "-b",
+                  "0.0.0.0:5001"
+                ],
+                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one",
+                "imagePullPolicy": "Always",
+                "name": "ipfs",
+                "ports": [
+                  {
+                    "containerPort": 4001,
+                    "name": "swarm"
+                  },
+                  {
+                    "containerPort": 5001,
+                    "name": "api"
+                  },
+                  {
+                    "containerPort": 8080,
+                    "name": "gateway"
+                  },
+                  {
+                    "containerPort": 9090,
+                    "name": "metrics"
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "512Mi"
+                  },
+                  "requests": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "512Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/data/ipfs",
+                    "name": "cas-ipfs-data"
+                  }
+                ]
+              }
+            ],
+            "volumes": [
+              {
+                "name": "cas-ipfs-data",
+                "persistentVolumeClaim": {
+                  "claimName": "cas-ipfs-data"
+                }
+              }
+            ]
+          }
+        },
+        "volumeClaimTemplates": [
+          {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+              "name": "cas-ipfs-data"
+            },
+            "spec": {
+              "accessModes": [
+                "ReadWriteOnce"
+              ],
+              "resources": {
+                "requests": {
+                  "storage": "10Gi"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/cas_postgres_service
+++ b/operator/src/network/testdata/default_stubs/cas_postgres_service
@@ -1,0 +1,31 @@
+Request {
+    method: "PATCH",
+    uri: "/api/v1/namespaces/keramik-test/services/cas-postgres?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "cas-postgres"
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "postgres",
+            "port": 5432,
+            "targetPort": 5432
+          }
+        ],
+        "selector": {
+          "app": "cas-postgres"
+        },
+        "type": "ClusterIP"
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/cas_postgres_stateful_set
+++ b/operator/src/network/testdata/default_stubs/cas_postgres_stateful_set
@@ -1,0 +1,124 @@
+Request {
+    method: "PATCH",
+    uri: "/apis/apps/v1/namespaces/keramik-test/statefulsets/cas-postgres?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "apps/v1",
+      "kind": "StatefulSet",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "cas-postgres"
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app": "cas-postgres"
+          }
+        },
+        "serviceName": "cas-postgres",
+        "template": {
+          "metadata": {
+            "labels": {
+              "app": "cas-postgres"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "env": [
+                  {
+                    "name": "POSTGRES_DB",
+                    "value": "anchor_db"
+                  },
+                  {
+                    "name": "POSTGRES_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "password",
+                        "name": "postgres-auth"
+                      }
+                    }
+                  },
+                  {
+                    "name": "POSTGRES_USER",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "username",
+                        "name": "postgres-auth"
+                      }
+                    }
+                  }
+                ],
+                "image": "postgres:15-alpine",
+                "imagePullPolicy": "Always",
+                "name": "postgres",
+                "ports": [
+                  {
+                    "containerPort": 5432,
+                    "name": "postgres"
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "512Mi"
+                  },
+                  "requests": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "512Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/var/lib/postgresql",
+                    "name": "postgres-data",
+                    "subPath": "ceradmic_data"
+                  }
+                ]
+              }
+            ],
+            "securityContext": {
+              "fsGroup": 70,
+              "runAsGroup": 70,
+              "runAsUser": 70
+            },
+            "volumes": [
+              {
+                "name": "postgres-data",
+                "persistentVolumeClaim": {
+                  "claimName": "postgres-data"
+                }
+              }
+            ]
+          }
+        },
+        "volumeClaimTemplates": [
+          {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+              "name": "postgres-data"
+            },
+            "spec": {
+              "accessModes": [
+                "ReadWriteOnce"
+              ],
+              "resources": {
+                "requests": {
+                  "storage": "10Gi"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/cas_service
+++ b/operator/src/network/testdata/default_stubs/cas_service
@@ -1,0 +1,32 @@
+Request {
+    method: "PATCH",
+    uri: "/api/v1/namespaces/keramik-test/services/cas?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "cas"
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "cas",
+            "port": 8081,
+            "protocol": "TCP",
+            "targetPort": 8081
+          }
+        ],
+        "selector": {
+          "app": "cas"
+        },
+        "type": "NodePort"
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/cas_stateful_set
+++ b/operator/src/network/testdata/default_stubs/cas_stateful_set
@@ -1,0 +1,181 @@
+Request {
+    method: "PATCH",
+    uri: "/apis/apps/v1/namespaces/keramik-test/statefulsets/cas?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "apps/v1",
+      "kind": "StatefulSet",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "cas"
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app": "cas"
+          }
+        },
+        "serviceName": "cas",
+        "template": {
+          "metadata": {
+            "labels": {
+              "app": "cas"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "env": [
+                  {
+                    "name": "NODE_ENV",
+                    "value": "dev"
+                  },
+                  {
+                    "name": "ANCHOR_EXPIRATION_PERIOD",
+                    "value": "300000"
+                  },
+                  {
+                    "name": "ANCHOR_SCHEDULE_EXPRESSION",
+                    "value": "0/1 * * * ? *"
+                  },
+                  {
+                    "name": "APP_MODE",
+                    "value": "bundled"
+                  },
+                  {
+                    "name": "APP_PORT",
+                    "value": "8081"
+                  },
+                  {
+                    "name": "BLOCKCHAIN_CONNECTOR",
+                    "value": "ethereum"
+                  },
+                  {
+                    "name": "ETH_NETWORK",
+                    "value": "ganache"
+                  },
+                  {
+                    "name": "ETH_RPC_URL",
+                    "value": "http://ganache:8545"
+                  },
+                  {
+                    "name": "ETH_WALLET_PK",
+                    "value": "0x16dd0990d19001c50eeea6d32e8fdeef40d3945962caf18c18c3930baa5a6ec9"
+                  },
+                  {
+                    "name": "ETH_CONTRACT_ADDRESS",
+                    "value": "0xD3f84Cf6Be3DD0EB16dC89c972f7a27B441A39f2"
+                  },
+                  {
+                    "name": "IPFS_API_URL",
+                    "value": "http://cas-ipfs:5001"
+                  },
+                  {
+                    "name": "IPFS_PUBSUB_TOPIC",
+                    "value": "local"
+                  },
+                  {
+                    "name": "LOG_LEVEL",
+                    "value": "debug"
+                  },
+                  {
+                    "name": "MERKLE_DEPTH_LIMIT",
+                    "value": "0"
+                  },
+                  {
+                    "name": "VALIDATE_RECORDS",
+                    "value": "false"
+                  },
+                  {
+                    "name": "DB_NAME",
+                    "value": "anchor_db"
+                  },
+                  {
+                    "name": "DB_HOST",
+                    "value": "cas-postgres"
+                  },
+                  {
+                    "name": "DB_USERNAME",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "username",
+                        "name": "postgres-auth"
+                      }
+                    }
+                  },
+                  {
+                    "name": "DB_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "password",
+                        "name": "postgres-auth"
+                      }
+                    }
+                  }
+                ],
+                "image": "ceramicnetwork/ceramic-anchor-service",
+                "imagePullPolicy": "Always",
+                "name": "cas",
+                "ports": [
+                  {
+                    "containerPort": 8081
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "512Mi"
+                  },
+                  "requests": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "512Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/cas/db",
+                    "name": "cas-data"
+                  }
+                ]
+              }
+            ],
+            "volumes": [
+              {
+                "name": "cas-data",
+                "persistentVolumeClaim": {
+                  "claimName": "cas-data"
+                }
+              }
+            ]
+          }
+        },
+        "volumeClaimTemplates": [
+          {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+              "name": "cas-data"
+            },
+            "spec": {
+              "accessModes": [
+                "ReadWriteOnce"
+              ],
+              "resources": {
+                "requests": {
+                  "storage": "10Gi"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/ceramic_admin_secret
+++ b/operator/src/network/testdata/default_stubs/ceramic_admin_secret
@@ -1,0 +1,6 @@
+Request {
+    method: "GET",
+    uri: "/api/v1/namespaces/keramik-test/secrets/ceramic-admin",
+    headers: {},
+    body: ,
+}

--- a/operator/src/network/testdata/default_stubs/ceramic_init_configmap
+++ b/operator/src/network/testdata/default_stubs/ceramic_init_configmap
@@ -1,0 +1,22 @@
+Request {
+    method: "PATCH",
+    uri: "/api/v1/namespaces/keramik-test/configmaps/ceramic-init?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "data": {
+        "ceramic-init.sh": "#!/bin/bash\n\nset -eo pipefail\n\nexport CERAMIC_ADMIN_DID=$(composedb did:from-private-key ${CERAMIC_ADMIN_PRIVATE_KEY})\n\nCERAMIC_ADMIN_DID=$CERAMIC_ADMIN_DID envsubst < /ceramic-init/daemon-config.json > /config/daemon-config.json\n",
+        "daemon-config.json": "{\n    \"anchor\": {},\n    \"http-api\": {\n        \"cors-allowed-origins\": [\n            \"${CERAMIC_CORS_ALLOWED_ORIGINS}\"\n        ],\n        \"admin-dids\": [\n            \"${CERAMIC_ADMIN_DID}\"\n        ]\n    },\n    \"ipfs\": {\n        \"mode\": \"remote\",\n        \"host\": \"${CERAMIC_IPFS_HOST}\"\n    },\n    \"logger\": {\n        \"log-level\": ${CERAMIC_LOG_LEVEL},\n        \"log-to-files\": false\n    },\n    \"metrics\": {\n        \"metrics-exporter-enabled\": false\n    },\n    \"network\": {\n        \"name\": \"${CERAMIC_NETWORK}\",\n        \"pubsub-topic\": \"${CERAMIC_NETWORK_TOPIC}\"\n    },\n    \"node\": {},\n    \"state-store\": {\n        \"mode\": \"fs\",\n        \"local-directory\": \"${CERAMIC_STATE_STORE_PATH}\"\n    },\n    \"indexing\": {\n        \"db\": \"sqlite://${CERAMIC_SQLITE_PATH}\",\n        \"allow-queries-before-historical-sync\": true,\n        \"disable-composedb\": true,\n        \"enable-historical-sync\": false\n    }\n}"
+      },
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "ceramic-init"
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/ceramic_service
+++ b/operator/src/network/testdata/default_stubs/ceramic_service
@@ -1,0 +1,46 @@
+Request {
+    method: "PATCH",
+    uri: "/api/v1/namespaces/keramik-test/services/ceramic?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "ceramic"
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "ceramic",
+            "port": 7007,
+            "protocol": "TCP"
+          },
+          {
+            "name": "rpc",
+            "port": 5001,
+            "protocol": "TCP"
+          },
+          {
+            "name": "swarm-tcp",
+            "port": 4001,
+            "protocol": "TCP"
+          },
+          {
+            "name": "swarm-udp",
+            "port": 4002,
+            "protocol": "UDP"
+          }
+        ],
+        "selector": {
+          "app": "ceramic"
+        },
+        "type": "ClusterIP"
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/ceramic_stateful_set
+++ b/operator/src/network/testdata/default_stubs/ceramic_stateful_set
@@ -1,0 +1,342 @@
+Request {
+    method: "PATCH",
+    uri: "/apis/apps/v1/namespaces/keramik-test/statefulsets/ceramic?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "apps/v1",
+      "kind": "StatefulSet",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "ceramic"
+      },
+      "spec": {
+        "podManagementPolicy": "Parallel",
+        "replicas": 0,
+        "selector": {
+          "matchLabels": {
+            "app": "ceramic"
+          }
+        },
+        "serviceName": "ceramic",
+        "template": {
+          "metadata": {
+            "annotations": {
+              "prometheus/path": "/metrics"
+            },
+            "labels": {
+              "app": "ceramic",
+              "managed-by": "keramik"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "command": [
+                  "/js-ceramic/packages/cli/bin/ceramic.js",
+                  "daemon",
+                  "--config",
+                  "/config/daemon-config.json",
+                  "--anchor-service-api",
+                  "http://cas:8081",
+                  "--ethereum-rpc",
+                  "http://ganache:8545"
+                ],
+                "env": [
+                  {
+                    "name": "CERAMIC_NETWORK",
+                    "value": "local"
+                  },
+                  {
+                    "name": "CERAMIC_NETWORK_TOPIC",
+                    "value": "/ceramic/local-keramik"
+                  },
+                  {
+                    "name": "CERAMIC_SQLITE_PATH",
+                    "value": "/ceramic-data/ceramic.db"
+                  },
+                  {
+                    "name": "CERAMIC_STATE_STORE_PATH",
+                    "value": "/ceramic-data/statestore"
+                  },
+                  {
+                    "name": "CERAMIC_IPFS_HOST",
+                    "value": "http://localhost:5001"
+                  },
+                  {
+                    "name": "CERAMIC_CORS_ALLOWED_ORIGINS",
+                    "value": ".*"
+                  },
+                  {
+                    "name": "CERAMIC_LOG_LEVEL",
+                    "value": "2"
+                  }
+                ],
+                "image": "3boxben/composedb:latest",
+                "imagePullPolicy": "Always",
+                "livenessProbe": {
+                  "httpGet": {
+                    "path": "/api/v0/node/healthcheck",
+                    "port": "api"
+                  },
+                  "initialDelaySeconds": 30,
+                  "periodSeconds": 15
+                },
+                "name": "ceramic",
+                "ports": [
+                  {
+                    "containerPort": 7007,
+                    "name": "api"
+                  }
+                ],
+                "readinessProbe": {
+                  "httpGet": {
+                    "path": "/api/v0/node/healthcheck",
+                    "port": "api"
+                  },
+                  "initialDelaySeconds": 30,
+                  "periodSeconds": 15
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "512Mi"
+                  },
+                  "requests": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "512Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/config",
+                    "name": "config-volume"
+                  },
+                  {
+                    "mountPath": "/ceramic-data",
+                    "name": "ceramic-data"
+                  }
+                ]
+              },
+              {
+                "env": [
+                  {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_BIND_ADDRESS",
+                    "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_METRICS",
+                    "value": "true"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
+                    "value": "0.0.0.0:9090"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_STORE_DIR",
+                    "value": "/data/ipfs"
+                  }
+                ],
+                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
+                "imagePullPolicy": "Always",
+                "name": "ipfs",
+                "ports": [
+                  {
+                    "containerPort": 4001,
+                    "name": "swarm-tcp",
+                    "protocol": "TCP"
+                  },
+                  {
+                    "containerPort": 4002,
+                    "name": "swarm-quic",
+                    "protocol": "UDP"
+                  },
+                  {
+                    "containerPort": 5001,
+                    "name": "rpc",
+                    "protocol": "TCP"
+                  },
+                  {
+                    "containerPort": 9090,
+                    "name": "metrics",
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "512Mi"
+                  },
+                  "requests": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "512Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/data/ipfs",
+                    "name": "ipfs-data"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "command": [
+                  "/bin/bash",
+                  "-c",
+                  "/ceramic-init/ceramic-init.sh"
+                ],
+                "env": [
+                  {
+                    "name": "CERAMIC_ADMIN_PRIVATE_KEY",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "private-key",
+                        "name": "ceramic-admin"
+                      }
+                    }
+                  },
+                  {
+                    "name": "CERAMIC_NETWORK",
+                    "value": "local"
+                  },
+                  {
+                    "name": "CERAMIC_NETWORK_TOPIC",
+                    "value": "/ceramic/local-keramik"
+                  },
+                  {
+                    "name": "CERAMIC_SQLITE_PATH",
+                    "value": "/ceramic-data/ceramic.db"
+                  },
+                  {
+                    "name": "CERAMIC_STATE_STORE_PATH",
+                    "value": "/ceramic-data/statestore"
+                  },
+                  {
+                    "name": "CERAMIC_IPFS_HOST",
+                    "value": "http://localhost:5001"
+                  },
+                  {
+                    "name": "CERAMIC_CORS_ALLOWED_ORIGINS",
+                    "value": ".*"
+                  },
+                  {
+                    "name": "CERAMIC_LOG_LEVEL",
+                    "value": "2"
+                  }
+                ],
+                "image": "3boxben/composedb:latest",
+                "imagePullPolicy": "Always",
+                "name": "init-ceramic-config",
+                "resources": {
+                  "limits": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "512Mi"
+                  },
+                  "requests": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "512Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/config",
+                    "name": "config-volume"
+                  },
+                  {
+                    "mountPath": "/ceramic-init",
+                    "name": "ceramic-init"
+                  }
+                ]
+              }
+            ],
+            "volumes": [
+              {
+                "emptyDir": {},
+                "name": "config-volume"
+              },
+              {
+                "configMap": {
+                  "defaultMode": 493,
+                  "name": "ceramic-init"
+                },
+                "name": "ceramic-init"
+              },
+              {
+                "name": "ceramic-data",
+                "persistentVolumeClaim": {
+                  "claimName": "ceramic-data"
+                }
+              },
+              {
+                "name": "ipfs-data",
+                "persistentVolumeClaim": {
+                  "claimName": "ipfs-data"
+                }
+              }
+            ]
+          }
+        },
+        "updateStrategy": {
+          "rollingUpdate": {
+            "maxUnavailable": "50%"
+          }
+        },
+        "volumeClaimTemplates": [
+          {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+              "name": "ceramic-data"
+            },
+            "spec": {
+              "accessModes": [
+                "ReadWriteOnce"
+              ],
+              "resources": {
+                "requests": {
+                  "storage": "10Gi"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+              "name": "ipfs-data"
+            },
+            "spec": {
+              "accessModes": [
+                "ReadWriteOnce"
+              ],
+              "resources": {
+                "requests": {
+                  "storage": "10Gi"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/ganache_service
+++ b/operator/src/network/testdata/default_stubs/ganache_service
@@ -1,0 +1,32 @@
+Request {
+    method: "PATCH",
+    uri: "/api/v1/namespaces/keramik-test/services/ganache?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "ganache"
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "ganache",
+            "port": 8545,
+            "protocol": "TCP",
+            "targetPort": 8545
+          }
+        ],
+        "selector": {
+          "app": "ganache"
+        },
+        "type": "NodePort"
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/ganache_stateful_set
+++ b/operator/src/network/testdata/default_stubs/ganache_stateful_set
@@ -1,0 +1,108 @@
+Request {
+    method: "PATCH",
+    uri: "/apis/apps/v1/namespaces/keramik-test/statefulsets/ganache?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "apps/v1",
+      "kind": "StatefulSet",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "ganache"
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "app": "ganache"
+          }
+        },
+        "serviceName": "ganache",
+        "template": {
+          "metadata": {
+            "labels": {
+              "app": "ganache"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "command": [
+                  "node",
+                  "/app/ganache-core.docker.cli.js",
+                  "--deterministic",
+                  "--db=/ganache/db",
+                  "--mnemonic",
+                  "move sense much taxi wave hurry recall stairs thank brother nut woman",
+                  "--networkId",
+                  "5777",
+                  "--hostname",
+                  "0.0.0.0",
+                  "-l",
+                  "80000000",
+                  "--quiet"
+                ],
+                "image": "trufflesuite/ganache-cli",
+                "imagePullPolicy": "Always",
+                "name": "ganache",
+                "ports": [
+                  {
+                    "containerPort": 8545
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "1Gi"
+                  },
+                  "requests": {
+                    "cpu": "250m",
+                    "ephemeral-storage": "1Gi",
+                    "memory": "1Gi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/ganache-data",
+                    "name": "ganache-data"
+                  }
+                ]
+              }
+            ],
+            "volumes": [
+              {
+                "name": "ganache-data",
+                "persistentVolumeClaim": {
+                  "claimName": "ganache-data"
+                }
+              }
+            ]
+          }
+        },
+        "volumeClaimTemplates": [
+          {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+              "name": "ganache-data"
+            },
+            "spec": {
+              "accessModes": [
+                "ReadWriteOnce"
+              ],
+              "resources": {
+                "requests": {
+                  "storage": "10Gi"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/keramik_peers_configmap
+++ b/operator/src/network/testdata/default_stubs/keramik_peers_configmap
@@ -1,0 +1,21 @@
+Request {
+    method: "PATCH",
+    uri: "/api/v1/namespaces/keramik-test/configmaps/keramik-peers?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "data": {
+        "peers.json": "[]"
+      },
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "keramik-peers"
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/namespace
+++ b/operator/src/network/testdata/default_stubs/namespace
@@ -1,0 +1,18 @@
+Request {
+    method: "PATCH",
+    uri: "/api/v1/namespaces/keramik-test?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "v1",
+      "kind": "Namespace",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "keramik-test"
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/postgres_auth_secret
+++ b/operator/src/network/testdata/default_stubs/postgres_auth_secret
@@ -1,0 +1,6 @@
+Request {
+    method: "GET",
+    uri: "/api/v1/namespaces/keramik-test/secrets/postgres-auth",
+    headers: {},
+    body: ,
+}

--- a/operator/src/network/testdata/default_stubs/status
+++ b/operator/src/network/testdata/default_stubs/status
@@ -1,0 +1,16 @@
+Request {
+    method: "PATCH",
+    uri: "/apis/keramik.3box.io/v1/networks/test/status?",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/merge-patch+json",
+    },
+    body: {
+      "status": {
+        "replicas": 0,
+        "ready_replicas": 0,
+        "namespace": null,
+        "peers": []
+      }
+    },
+}

--- a/operator/src/network/testdata/default_stubs/status
+++ b/operator/src/network/testdata/default_stubs/status
@@ -8,7 +8,7 @@ Request {
     body: {
       "status": {
         "replicas": 0,
-        "ready_replicas": 0,
+        "readyReplicas": 0,
         "namespace": null,
         "peers": []
       }

--- a/operator/src/network/utils.rs
+++ b/operator/src/network/utils.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, bail, Result};
-use keramik_common::peer_info::{PeerId, PeerIdx};
+use async_trait::async_trait;
+use keramik_common::peer_info::{PeerIdx, PeerInfo};
 use multiaddr::{Multiaddr, Protocol};
 use multihash::Multihash;
+use unimock::unimock;
 
 use crate::network::controller::{
     CERAMIC_SERVICE_NAME, CERAMIC_SERVICE_RPC_PORT, CERAMIC_STATEFUL_SET_NAME,
@@ -13,59 +15,76 @@ struct ErrorResponse {
     message: String,
 }
 
-pub fn peer_rpc_addr(ns: &str, peer: PeerIdx) -> String {
+/// Define the behavior we consume from the IPFS RPC API.
+#[unimock(api=RpcClientMock)]
+#[async_trait]
+pub trait RpcClient {
+    async fn peer_info(&self, ns: &str, peer: PeerIdx) -> Result<PeerInfo>;
+}
+
+pub struct HttpRpcClient;
+
+fn peer_rpc_addr(ns: &str, peer: PeerIdx) -> String {
     format!("http://{CERAMIC_STATEFUL_SET_NAME}-{peer}.{CERAMIC_SERVICE_NAME}.{ns}.svc.cluster.local:{CERAMIC_SERVICE_RPC_PORT}")
 }
 
-pub async fn peer_addr(ns: &str, peer: PeerIdx) -> Result<(PeerId, String, Vec<String>)> {
-    let rpc_addr = peer_rpc_addr(ns, peer);
-    let client = reqwest::Client::new();
-    let resp = client
-        .post(format!("{}/api/v0/id", rpc_addr))
-        .send()
-        .await?;
-    if !resp.status().is_success() {
-        let data: ErrorResponse = resp.json().await?;
-        bail!("peer id failed: {}", data.message)
-    }
+#[async_trait]
+impl RpcClient for HttpRpcClient {
+    async fn peer_info(&self, ns: &str, index: PeerIdx) -> Result<PeerInfo> {
+        let rpc_addr = peer_rpc_addr(ns, index);
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("{}/api/v0/id", rpc_addr))
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let data: ErrorResponse = resp.json().await?;
+            bail!("peer id failed: {}", data.message)
+        }
 
-    #[derive(serde::Deserialize)]
-    struct Response {
-        #[serde(rename = "ID")]
-        id: String,
-        #[serde(rename = "Addresses")]
-        addresses: Vec<String>,
-    }
-    let data: Response = resp.json().await?;
+        #[derive(serde::Deserialize)]
+        struct Response {
+            #[serde(rename = "ID")]
+            id: String,
+            #[serde(rename = "Addresses")]
+            addresses: Vec<String>,
+        }
+        let data: Response = resp.json().await?;
 
-    let p2p_proto = Protocol::P2p(Multihash::from_bytes(
-        &multibase::Base::Base58Btc.decode(data.id.clone())?,
-    )?);
-    // We expect to find at least one non loop back address
-    let addrs = data
-        .addresses
-        .iter()
-        .map(|addr| -> Multiaddr { addr.parse().expect("should be a valid multiaddr") })
-        .filter(|addr| {
-            // Address must have both a non loopback ip4 address and a tcp or quic endpoint
-            addr.iter().any(|proto| match proto {
-                multiaddr::Protocol::Ip4(ip4) => !ip4.is_loopback(),
-                _ => false,
+        let p2p_proto = Protocol::P2p(Multihash::from_bytes(
+            &multibase::Base::Base58Btc.decode(data.id.clone())?,
+        )?);
+        // We expect to find at least one non loop back address
+        let p2p_addrs = data
+            .addresses
+            .iter()
+            .map(|addr| -> Multiaddr { addr.parse().expect("should be a valid multiaddr") })
+            .filter(|addr| {
+                // Address must have both a non loopback ip4 address and a tcp or quic endpoint
+                addr.iter().any(|proto| match proto {
+                    multiaddr::Protocol::Ip4(ip4) => !ip4.is_loopback(),
+                    _ => false,
+                })
             })
-        })
-        // Add peer id to multiaddrs
-        .map(|mut addr| {
-            addr.push(p2p_proto.clone());
-            addr.to_string()
-        })
-        .collect::<Vec<String>>();
+            // Add peer id to multiaddrs
+            .map(|mut addr| {
+                addr.push(p2p_proto.clone());
+                addr.to_string()
+            })
+            .collect::<Vec<String>>();
 
-    if !addrs.is_empty() {
-        Ok((data.id, rpc_addr, addrs))
-    } else {
-        Err(anyhow!(
-            "peer {} does not have any valid non loopback addresses",
-            peer
-        ))
+        if !p2p_addrs.is_empty() {
+            Ok(PeerInfo {
+                index,
+                peer_id: data.id,
+                rpc_addr,
+                p2p_addrs,
+            })
+        } else {
+            Err(anyhow!(
+                "peer {} does not have any valid non loopback addresses",
+                index
+            ))
+        }
     }
 }


### PR DESCRIPTION
These tests follow a basic pattern. First the controller is basically responsible for making API calls to the k8s API. So to test it we use a combination of mocks, stubs and expect_test to build a basic test framework. The mock/stubs capture the requests made to the API and return responses. The `expect_test` crate is used to assert the correctness of the requests while making it easy to update the tests when the code itself is changed. Additionally an `ExpectPatch` concept is added that allows for  patching the default stubs instead of reproducing their entire contents for each test.

