### PR TITLE
feat: add support for resource limits

### DIFF
--- a/operator/src/network/testdata/default_stubs/ceramic_stateful_set
+++ b/operator/src/network/testdata/default_stubs/ceramic_stateful_set
@@ -247,12 +247,12 @@ Request {
                   "limits": {
                     "cpu": "250m",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
                     "cpu": "250m",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [


### PR DESCRIPTION
With this change CAS (cas, cas_ipfs, ganache and postgres) along with Ceramic nodes (both js and ipfs nodes) can have their resource limits configured.

Currently request == limits.