### PR TITLE
feat: add bootstrap for cas-ipfs node

### DIFF
--- a/common/src/peer_info.rs
+++ b/common/src/peer_info.rs
@@ -2,16 +2,50 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Peers are identified via a total ordering starting at 0.
+/// Peers are identified via a total ordering.
 pub type PeerIdx = i32;
 
 /// P2p peer id generated via libp2p.
 pub type PeerId = String;
 
-/// Describes a peer.
+/// Represents a generic Peer in the network.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum Peer {
+    /// Describes a peer that participates via Ceramic protocols.
+    Ceramic(CeramicPeerInfo),
+    /// Describes a peer that only participates using IPFS protocols.
+    Ipfs(IpfsPeerInfo),
+}
+
+impl Peer {
+    /// Report the index of the peer within the total order.
+    pub fn index(&self) -> PeerIdx {
+        match self {
+            Peer::Ceramic(p) => p.index,
+            Peer::Ipfs(p) => p.index,
+        }
+    }
+    /// Report address of the IPFS RPC endpoint
+    pub fn ipfs_rpc_addr(&self) -> &str {
+        match self {
+            Peer::Ceramic(p) => &p.ipfs_rpc_addr,
+            Peer::Ipfs(p) => &p.ipfs_rpc_addr,
+        }
+    }
+    /// Report peer to peer address of the peer
+    pub fn p2p_addrs(&self) -> &[String] {
+        match self {
+            Peer::Ceramic(p) => p.p2p_addrs.as_slice(),
+            Peer::Ipfs(p) => p.p2p_addrs.as_slice(),
+        }
+    }
+}
+
+/// Describes a peer that participates via Ceramic protocols.
 #[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct PeerInfo {
+pub struct CeramicPeerInfo {
     /// The index of the peer within the total order.
     pub index: PeerIdx,
     /// The public ID of the peer.
@@ -20,6 +54,20 @@ pub struct PeerInfo {
     pub ipfs_rpc_addr: String,
     /// Ceramic API address of the peer.
     pub ceramic_addr: String,
+    /// Set of p2p addresses of the peer.
+    /// Each address contains the /p2p/<peer_id> protocol.
+    pub p2p_addrs: Vec<String>,
+}
+/// Describes a peer that only participates using IPFS protocols.
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct IpfsPeerInfo {
+    /// The index of the peer within the total order.
+    pub index: PeerIdx,
+    /// The public ID of the peer.
+    pub peer_id: PeerId,
+    /// RPC address of the peer.
+    pub ipfs_rpc_addr: String,
     /// Set of p2p addresses of the peer.
     /// Each address contains the /p2p/<peer_id> protocol.
     pub p2p_addrs: Vec<String>,

--- a/operator/src/network/mod.rs
+++ b/operator/src/network/mod.rs
@@ -17,7 +17,7 @@ pub use bootstrap::BootstrapSpec;
 pub use ceramic::CeramicSpec;
 pub use controller::run;
 
-use keramik_common::peer_info::PeerInfo;
+use keramik_common::peer_info::Peer;
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -54,5 +54,5 @@ pub struct NetworkStatus {
     /// K8s namespace this network is deployed in
     pub namespace: Option<String>,
     /// Information about each Ceramic peer
-    pub peers: Vec<PeerInfo>,
+    pub peers: Vec<Peer>,
 }

--- a/operator/src/network/peers.rs
+++ b/operator/src/network/peers.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
 
-use keramik_common::peer_info::PeerInfo;
+use keramik_common::peer_info::Peer;
 
 pub const PEERS_MAP_KEY: &str = "peers.json";
 
-pub fn peer_config_map_data(peers: &[PeerInfo]) -> BTreeMap<String, String> {
+pub fn peer_config_map_data(peers: &[Peer]) -> BTreeMap<String, String> {
     BTreeMap::from_iter(vec![(
         PEERS_MAP_KEY.to_owned(),
         serde_json::to_string(peers).unwrap(),

--- a/operator/src/network/testdata/bootstrap_job_cas_ipfs
+++ b/operator/src/network/testdata/bootstrap_job_cas_ipfs
@@ -1,0 +1,75 @@
+Request {
+    method: "PATCH",
+    uri: "/apis/batch/v1/namespaces/keramik-test/jobs/bootstrap?&fieldManager=keramik",
+    headers: {
+        "accept": "application/json",
+        "content-type": "application/apply-patch+yaml",
+    },
+    body: {
+      "apiVersion": "batch/v1",
+      "kind": "Job",
+      "metadata": {
+        "labels": {
+          "managed-by": "keramik"
+        },
+        "name": "bootstrap",
+        "ownerReferences": []
+      },
+      "spec": {
+        "backoffLimit": 4,
+        "template": {
+          "spec": {
+            "containers": [
+              {
+                "command": [
+                  "/usr/bin/keramik-runner",
+                  "bootstrap"
+                ],
+                "env": [
+                  {
+                    "name": "RUNNER_OTLP_ENDPOINT",
+                    "value": "http://otel:4317"
+                  },
+                  {
+                    "name": "RUST_LOG",
+                    "value": "info,keramik_runner=debug"
+                  },
+                  {
+                    "name": "BOOTSTRAP_METHOD",
+                    "value": "sentinel"
+                  },
+                  {
+                    "name": "BOOTSTRAP_N",
+                    "value": "3"
+                  },
+                  {
+                    "name": "BOOTSTRAP_PEERS_PATH",
+                    "value": "/keramik-peers/peers.json"
+                  }
+                ],
+                "image": "public.ecr.aws/r5b3e0r5/3box/keramik-runner",
+                "imagePullPolicy": "Always",
+                "name": "bootstrap",
+                "volumeMounts": [
+                  {
+                    "mountPath": "/keramik-peers",
+                    "name": "keramik-peers"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Never",
+            "volumes": [
+              {
+                "configMap": {
+                  "defaultMode": 493,
+                  "name": "keramik-peers"
+                },
+                "name": "keramik-peers"
+              }
+            ]
+          }
+        }
+      }
+    },
+}

--- a/operator/src/utils/mod.rs
+++ b/operator/src/utils/mod.rs
@@ -11,7 +11,7 @@ use k8s_openapi::{
     apimachinery::pkg::apis::meta::v1::OwnerReference,
 };
 
-use crate::network::utils::RpcClient;
+use crate::network::utils::IpfsRpcClient;
 
 use kube::{
     api::{Patch, PatchParams},
@@ -32,7 +32,7 @@ impl<R> Context<R> {
     /// Create new context
     pub fn new(k_client: Client, rpc_client: R) -> Self
     where
-        R: RpcClient,
+        R: IpfsRpcClient,
     {
         Context {
             k_client,
@@ -65,7 +65,7 @@ pub fn managed_labels() -> Option<BTreeMap<String, String>> {
 
 /// Apply a Service
 pub async fn apply_service(
-    cx: Arc<Context<impl RpcClient>>,
+    cx: Arc<Context<impl IpfsRpcClient>>,
     ns: &str,
     orefs: Vec<OwnerReference>,
     name: &str,
@@ -93,7 +93,7 @@ pub async fn apply_service(
 
 /// Apply a Job
 pub async fn apply_job(
-    cx: Arc<Context<impl RpcClient>>,
+    cx: Arc<Context<impl IpfsRpcClient>>,
     ns: &str,
     orefs: Vec<OwnerReference>,
     name: &str,
@@ -119,7 +119,7 @@ pub async fn apply_job(
 
 /// Apply a stateful set in namespace
 pub async fn apply_stateful_set(
-    cx: Arc<Context<impl RpcClient>>,
+    cx: Arc<Context<impl IpfsRpcClient>>,
     ns: &str,
     orefs: Vec<OwnerReference>,
     name: &str,
@@ -147,7 +147,7 @@ pub async fn apply_stateful_set(
 
 /// Apply account in namespace
 pub async fn apply_account(
-    cx: Arc<Context<impl RpcClient>>,
+    cx: Arc<Context<impl IpfsRpcClient>>,
     ns: &str,
     orefs: Vec<OwnerReference>,
     name: &str,
@@ -173,7 +173,7 @@ pub async fn apply_account(
 
 /// Apply cluster role
 pub async fn apply_cluster_role(
-    cx: Arc<Context<impl RpcClient>>,
+    cx: Arc<Context<impl IpfsRpcClient>>,
     _ns: &str,
     orefs: Vec<OwnerReference>,
     name: &str,
@@ -198,7 +198,7 @@ pub async fn apply_cluster_role(
 
 /// Apply cluster role binding
 pub async fn apply_cluster_role_binding(
-    cx: Arc<Context<impl RpcClient>>,
+    cx: Arc<Context<impl IpfsRpcClient>>,
     orefs: Vec<OwnerReference>,
     name: &str,
     crb: ClusterRoleBinding,
@@ -224,7 +224,7 @@ pub async fn apply_cluster_role_binding(
 
 /// Apply a config map
 pub async fn apply_config_map(
-    cx: Arc<Context<impl RpcClient>>,
+    cx: Arc<Context<impl IpfsRpcClient>>,
     ns: &str,
     orefs: Vec<OwnerReference>,
     name: &str,


### PR DESCRIPTION
With this change the keramik-peers config map will contain both ceramic peers as well as generic IPFS peers.

The bootstrap methods have been updated accordingly.

#34 should merge first.