### PR TITLE
fix: stop adding cas-ipfs status with each reconcile

### DIFF
--- a/operator/src/simulation/controller.rs
+++ b/operator/src/simulation/controller.rs
@@ -236,7 +236,13 @@ async fn get_num_peers(
     let map = config_maps.get(PEERS_CONFIG_MAP_NAME).await?;
     let data = map.data.unwrap();
     let value = data.get(PEERS_MAP_KEY).unwrap();
-    let peers: Vec<Peer> = serde_json::from_str(value).unwrap();
+    let peers: Vec<Peer> = serde_json::from_str::<Vec<Peer>>(value)
+        .unwrap()
+        .into_iter()
+        .filter(|peer| matches!(peer, Peer::Ceramic(_)))
+        .collect();
+
+    debug!(peers = peers.len(), "get_num_peers");
     Ok(peers.len() as u32)
 }
 

--- a/operator/src/utils/test.rs
+++ b/operator/src/utils/test.rs
@@ -32,7 +32,7 @@ where
     }
 }
 
-pub async fn timeout_after_1s(handle: tokio::task::JoinHandle<()>) {
+pub async fn timeout_after_1s<T>(handle: tokio::task::JoinHandle<T>) -> T {
     tokio::time::timeout(std::time::Duration::from_secs(1), handle)
         .await
         .expect("timeout on mock apiserver")
@@ -57,7 +57,7 @@ impl ApiServerVerifier {
         &mut self,
         expected_request: impl Expectation,
         resource: R,
-    ) -> Result<()>
+    ) -> Result<R>
     where
         R: WithStatus + Serialize,
         <R as WithStatus>::Status: for<'de> Deserialize<'de>,
@@ -80,7 +80,7 @@ impl ApiServerVerifier {
                 .body(Body::from(response))
                 .unwrap(),
         );
-        Ok(())
+        Ok(resource)
     }
 
     pub async fn handle_apply(&mut self, expected_request: impl Expectation) -> Result<()> {


### PR DESCRIPTION
Prior to this change the cas-ipfs peer info would be added to the network status with each call to reconcile. Additionally the simulation logic did not correctly ignore non Ceramic peers.