### PR TITLE
fix: ceramic service should be headless for pod dns

### DIFF
--- a/operator/src/network/ceramic.rs
+++ b/operator/src/network/ceramic.rs
@@ -121,6 +121,7 @@ pub fn service_spec() -> ServiceSpec {
             },
         ]),
         selector: selector_labels(CERAMIC_APP),
+        cluster_ip: Some("None".to_owned()),
         type_: Some("ClusterIP".to_owned()),
         ..Default::default()
     }

--- a/operator/src/network/testdata/default_stubs/ceramic_service
+++ b/operator/src/network/testdata/default_stubs/ceramic_service
@@ -16,6 +16,7 @@ Request {
         "ownerReferences": []
       },
       "spec": {
+        "clusterIP": "None",
         "ports": [
           {
             "name": "api",


### PR DESCRIPTION
One of those "I'm not sure how it's working on kind and AWS" issues.

Problem:
  DNS records for pods in a statefulset with attached service are not generated on GKE. They are on kind and EKS.

Analysis:
  According to the spec, they shouldn't be!?!  

  Service with ClusterIP (current config). 
    https://github.com/kubernetes/dns/blob/master/docs/specification.md#23---records-for-a-service-with-clusterip 

  [headless service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services)
    https://github.com/kubernetes/dns/blob/master/docs/specification.md#24---records-for-a-headless-service 

This PR makes the `ceramic` service headless, which means there is no proxying though a ClusterIP to a single address. All addresses will be returned.

```
root@keramik-operator-6969997f66-mnnn9:/# dig +short ceramic.keramik-js-ceramic-headless.svc.cluster.local
10.124.8.4
10.124.9.4
root@keramik-operator-6969997f66-mnnn9:/# dig +short ceramic-0.ceramic.keramik-js-ceramic-headless.svc.clus
ter.local
10.124.8.4
root@keramik-operator-6969997f66-mnnn9:/# dig +short ceramic-1.ceramic.keramik-js-ceramic-headless.svc.clus
ter.local
10.124.9.4
```

This behavior also matches GCP docs https://cloud.google.com/kubernetes-engine/docs/concepts/statefulset#plan_networking_for_statefulsets (Headless Service section)

I don't think this will affect the design of keramik Networks or Simulations as we're expecting to address each node individually anyway.

Deployed and tested on GCP it seems to be working. Still works in kind.
