### PR TITLE
fix: cas wallet address and sqs queue name

### DIFF
--- a/operator/src/network/cas.rs
+++ b/operator/src/network/cas.rs
@@ -133,6 +133,11 @@ pub fn cas_stateful_set_spec(
     let config = config.into();
     let mut env = vec![
         EnvVar {
+            name: "SQS_QUEUE_URL".to_owned(),
+            value: Some("".to_owned()),
+            ..Default::default()
+        },
+        EnvVar {
             name: "NODE_ENV".to_owned(),
             value: Some("dev".to_owned()),
             ..Default::default()
@@ -175,7 +180,7 @@ pub fn cas_stateful_set_spec(
         EnvVar {
             name: "ETH_WALLET_PK".to_owned(),
             value: Some(
-                "0x16dd0990d19001c50eeea6d32e8fdeef40d3945962caf18c18c3930baa5a6ec9".to_owned(),
+                "0x06dd0990d19001c57eeea6d32e8fdeee40d3945962caf18c18c3930baa5a6ec9".to_owned(),
             ),
             ..Default::default()
         },

--- a/operator/src/network/testdata/default_stubs/cas_stateful_set
+++ b/operator/src/network/testdata/default_stubs/cas_stateful_set
@@ -36,6 +36,10 @@ Request {
               {
                 "env": [
                   {
+                    "name": "SQS_QUEUE_URL",
+                    "value": ""
+                  },
+                  {
                     "name": "NODE_ENV",
                     "value": "dev"
                   },
@@ -69,7 +73,7 @@ Request {
                   },
                   {
                     "name": "ETH_WALLET_PK",
-                    "value": "0x16dd0990d19001c50eeea6d32e8fdeef40d3945962caf18c18c3930baa5a6ec9"
+                    "value": "0x06dd0990d19001c57eeea6d32e8fdeee40d3945962caf18c18c3930baa5a6ec9"
                   },
                   {
                     "name": "ETH_CONTRACT_ADDRESS",


### PR DESCRIPTION
The latest CAS images fail with an AWS_DEFAULT_REGION missing error because it's trying to use SQS, it should not be trying to use SQS.

Setting the `SQS_QUEUE_URL` to `""` causes it to skip SQS steps and operate locally.

I'm not sure where the existing `ETH_WALLET_PK` came from, but it isn't working.
I took the first address from the ganache output for the new key, it has been consistent between runs.