### PR TITLE
feat: add service for migration tests

### DIFF
--- a/k8s/tests/kustomization.yaml
+++ b/k8s/tests/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+namespace: keramik-migration-tests
+
+resources:
+  - ./manifests/tests.yaml
+
+images:
+  - name: migration-tests
+    newName: public.ecr.aws/r5b3e0r5/3box/rust-ceramic-migration-tests
+    newTag: latest

--- a/k8s/tests/manifests/tests.yaml
+++ b/k8s/tests/manifests/tests.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: migration-tests
+spec:
+  replicas: 2
+  ceramic:
+    ipfs:
+      rust: {}
+
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: migration-tests
+  namespace: keramik-migration-tests
+  labels:
+    app: migration-tests
+spec:
+  template:
+    metadata:
+      labels:
+        app: migration-tests
+    spec:
+      initContainers:
+        - name: init-tests
+          image: stedolan/jq
+          resources:
+            limits:
+              cpu: 250m
+              ephemeral-storage: 1Gi
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              ephemeral-storage: 1Gi
+              memory: 512Mi
+          command:
+            - "/bin/bash"
+            - "-c"
+            - "mkdir /config/env && CERAMIC_URLS=$(cat /peers/peers.json | jq -j '[.[].ceramic.ceramicAddr] | join(\",\")') && echo \"CERAMIC_URLS=$CERAMIC_URLS\" > /config/.env"
+          volumeMounts:
+            - name: peers-volume
+              mountPath: /peers
+            - name: config-volume
+              mountPath: /config
+          envFrom:
+            - configMapRef:
+                name: keramik-peers
+      restartPolicy: Never
+      containers:
+        - name: migration-tests
+          image: migration-tests
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 250m
+              ephemeral-storage: 1Gi
+              memory: 512Mi
+            requests:
+              cpu: 250m
+              ephemeral-storage: 1Gi
+              memory: 512Mi
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
+          env:
+            - name: ENV_PATH
+              value: "/config/.env"
+          args: ["test", "--show-output"]
+      volumes:
+        - name: peers-volume
+          configMap:
+            name: keramik-peers
+        - name: config-volume
+          emptyDir: {}


### PR DESCRIPTION
Output with empty tests that print the Ceramic URLs corresponding to the associated network.
```
running 2 tests                                                                                                                                  
test api::tests::test_1 ... ok                                                                                                                   
test api::tests::test_2 ... ok                                                                                                                   
                                                                                                                                                 
successes:                                                                                                                                       
                                                                                                                                                 
---- api::tests::test_1 stdout ----                                                                                                              
Hello Ceramic!                                                                                                                                   
"http://ceramic-0.ceramic.keramik-migration-tests.svc.cluster.local:7007,http://ceramic-1.ceramic.keramik-migration-tests.svc.cluster.local:7007"
                                                                                                                                                 
---- api::tests::test_2 stdout ----                                                                                                              
Goodbye Ceramic!                                                                                                                                 
"http://ceramic-0.ceramic.keramik-migration-tests.svc.cluster.local:7007,http://ceramic-1.ceramic.keramik-migration-tests.svc.cluster.local:7007"
                                                                                                                                                 
                                                                                                                                                 
successes:                                                                                                                                       
    api::tests::test_1                                                                                                                           
    api::tests::test_2                                                                                                                           
                                                                                                                                                 
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s                                                    
```
Tests are built from [this](https://github.com/3box/rust-ceramic-migration-tests) repository.