### PR TITLE
fix: update check-network to handle CAS

### DIFF
--- a/k8s/tests/check-network.sh
+++ b/k8s/tests/check-network.sh
@@ -12,7 +12,17 @@ check_status() {
   status | jq -r 'if (.status != "Failure") and (.status.readyReplicas == .status.replicas) then true else false end'
 }
 
+
+available_peers() {
+  jq -r '. | length' < /peers/peers.json
+}
+
 populate_peers() {
+  # Sanity check we actually have any peers.
+  if [ "$(available_peers)" == "0" ]; then
+    exit 1
+  fi
+
   mkdir /config/env
   CERAMIC_URLS=$(jq -j '[.[].ceramic.ipfsRpcAddr | select(.)] | join(",")' < /peers/peers.json)
   COMPOSEDB_URLS=$(jq -j '[.[].ceramic.ceramicAddr | select(.)] | join(",")' < /peers/peers.json)

--- a/k8s/tests/manifests/tests.yaml
+++ b/k8s/tests/manifests/tests.yaml
@@ -85,7 +85,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: keramik-peers
-      restartPolicy: Never
+      restartPolicy: OnFailure
       containers:
         - name: migration-tests
           image: migration-tests


### PR DESCRIPTION
There were two bugs in check-network:

1. If CAS was configured it would not detect the network is ready because there would be more peers in peers.json than expect. Keramik already accounts for this in its replicas and readyReplicas counts. So the script has been changed to only check the status counts instead of counting peers itself.
2. If CAS was configured it would emit an empty ComposeDB URL.