### PR TITLE
fix: add missing camelCase attribute

### DIFF
--- a/operator/src/network/mod.rs
+++ b/operator/src/network/mod.rs
@@ -34,6 +34,7 @@ use serde::{Deserialize, Serialize};
     status = "NetworkStatus",
     derive = "PartialEq"
 )]
+#[serde(rename_all = "camelCase")]
 pub struct NetworkSpec {
     /// Number of Ceramic peers
     pub replicas: i32,


### PR DESCRIPTION
A few of the new top level fields on the Network spec were using underscores. This fixes then to use camelCase.