### PR TITLE
Add link to docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ Keramik is a Kubernetes operator for simulating Ceramic networks.
 
 The `k8s` directory contains the kubernetes manifests for deploying Keramik.
 
-## Local Documentation
+## Usage guide
+[Have a look in the documentation](https://3box.github.io/keramik/).
+
+### Build Documentation Locally
 Documentation is done using [mdbook](https://rust-lang.github.io/mdBook/guide/installation.html)
 
     cargo install mdbook


### PR DESCRIPTION
I saw that we mentioned we have a docsite in #74. This should be linked from the readme so that it can be found.