### PR TITLE
fix: handle case where peers is null not an empty list

### DIFF
--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -23,7 +23,7 @@ use kube::{
     Resource,
 };
 use rand::RngCore;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, trace, warn};
 
 use crate::network::{
     bootstrap,
@@ -590,10 +590,11 @@ async fn update_peer_status(
         let peer_status = match cx.rpc_client.peer_status(peer.ipfs_rpc_addr()).await {
             Ok(res) => res,
             Err(err) => {
-                debug!(%err, peer = peer.id(), "failed to get peer status for peer");
+                warn!(%err, peer = peer.id(), "failed to get peer status for peer");
                 continue;
             }
         };
+        debug!(peer = peer.id(), ?peer_status, "peer status");
         min_connected_peers = Some(min(
             min_connected_peers.unwrap_or(peer_status.connected_peers),
             peer_status.connected_peers,

--- a/operator/src/network/utils.rs
+++ b/operator/src/network/utils.rs
@@ -106,11 +106,11 @@ impl IpfsRpcClient for HttpRpcClient {
         #[derive(serde::Deserialize)]
         struct Response {
             #[serde(rename = "Peers")]
-            peers: Vec<Peer>,
+            peers: Option<Vec<Peer>>,
         }
         let data: Response = resp.json().await?;
         Ok(PeerStatus {
-            connected_peers: data.peers.len() as i32,
+            connected_peers: data.peers.unwrap_or_default().len() as i32,
         })
     }
 }


### PR DESCRIPTION
Prior to this change checking the peers status would error if the peers json was null vs an empty list. We now handle both cases.