### PR TITLE
refactor: create spec only crate without default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,185 +3,6 @@
 version = 3
 
 [[package]]
-name = "actix-codec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617a8268e3537fe1d8c9ead925fca49ef6400927ee7bc26750e90ecee14ce4b8"
-dependencies = [
- "bitflags 1.3.2",
- "bytes",
- "futures-core",
- "futures-sink",
- "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "actix-http"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92ef85799cba03f76e4f7c10f533e66d87c9a7e7055f3391f09000ad8351bc9"
-dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "actix-utils",
- "ahash 0.8.3",
- "base64 0.21.4",
- "bitflags 2.4.0",
- "brotli",
- "bytes",
- "bytestring",
- "derive_more",
- "encoding_rs",
- "flate2",
- "futures-core",
- "h2",
- "http",
- "httparse",
- "httpdate",
- "itoa",
- "language-tags",
- "local-channel",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand 0.8.5",
- "sha1",
- "smallvec",
- "tokio",
- "tokio-util",
- "tracing",
- "zstd",
-]
-
-[[package]]
-name = "actix-macros"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
-dependencies = [
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "actix-router"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66ff4d247d2b160861fa2866457e85706833527840e4133f8f49aa423a38799"
-dependencies = [
- "bytestring",
- "http",
- "regex",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "actix-rt"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
-dependencies = [
- "futures-core",
- "tokio",
-]
-
-[[package]]
-name = "actix-server"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb13e7eef0423ea6eab0e59f6c72e7cb46d33691ad56a726b3cd07ddec2c2d4"
-dependencies = [
- "actix-rt",
- "actix-service",
- "actix-utils",
- "futures-core",
- "futures-util",
- "mio",
- "socket2 0.5.4",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "actix-service"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
-dependencies = [
- "futures-core",
- "paste",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-utils"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
-dependencies = [
- "local-waker",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-web"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4a5b5e29603ca8c94a77c65cf874718ceb60292c5a5c3e5f4ace041af462b9"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-macros",
- "actix-router",
- "actix-rt",
- "actix-server",
- "actix-service",
- "actix-utils",
- "actix-web-codegen",
- "ahash 0.8.3",
- "bytes",
- "bytestring",
- "cfg-if",
- "cookie",
- "derive_more",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "itoa",
- "language-tags",
- "log",
- "mime",
- "once_cell",
- "pin-project-lite",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "smallvec",
- "socket2 0.5.4",
- "time",
- "url",
-]
-
-[[package]]
-name = "actix-web-codegen"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
-dependencies = [
- "actix-router",
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,21 +47,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2135563fb5c609d2b2b87c1e8ce7bc41b0b45430fa9661f457981503dd5bf0"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -762,27 +568,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "3.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,15 +599,6 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
-
-[[package]]
-name = "bytestring"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238e4886760d98c4f899360c834fa93e62cf7f721ac3c2da375cbdf4b8679aae"
-dependencies = [
- "bytes",
-]
 
 [[package]]
 name = "cacaos"
@@ -868,7 +644,6 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "jobserver",
  "libc",
 ]
 
@@ -1111,12 +886,6 @@ name = "contextual"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ca71f324d19e85a2e976be04b5ecbb193253794a75adfe2e5044c8bef03f6a"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
@@ -1559,19 +1328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "did-method-key"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,12 +1426,6 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
-
-[[package]]
-name = "dtoa"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "dyn-clone"
@@ -2377,9 +2127,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "log",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
 ]
@@ -2573,15 +2321,6 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
-
-[[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -2826,16 +2565,12 @@ dependencies = [
 name = "keramik-common"
 version = "0.1.0"
 dependencies = [
- "actix-web",
  "anyhow",
  "gethostname",
  "opentelemetry",
  "opentelemetry-otlp",
  "schemars",
  "serde",
- "serde_json",
- "tokio",
- "tonic",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -2862,7 +2597,6 @@ dependencies = [
  "multibase 0.9.1",
  "multihash 0.17.0",
  "opentelemetry",
- "opentelemetry-otlp",
  "rand 0.8.5",
  "reqwest",
  "schemars",
@@ -2871,12 +2605,9 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
- "tonic",
  "tower-test",
  "tracing",
  "tracing-log",
- "tracing-opentelemetry",
- "tracing-subscriber",
  "tracing-test",
 ]
 
@@ -2891,12 +2622,8 @@ dependencies = [
  "goose",
  "keramik-common",
  "libipld 0.16.0",
- "multiaddr",
- "multibase 0.9.1",
  "multihash 0.17.0",
  "opentelemetry",
- "opentelemetry-otlp",
- "prometheus-client",
  "rand 0.8.5",
  "redis",
  "reqwest",
@@ -2904,11 +2631,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tonic",
  "tracing",
  "tracing-log",
- "tracing-opentelemetry",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2939,15 +2663,12 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
  "hyper-timeout",
  "jsonpath_lib",
  "k8s-openapi",
  "kube-core",
  "pem",
  "pin-project",
- "rustls",
- "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
@@ -3031,12 +2752,6 @@ name = "langtag"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed60c85f254d6ae8450cec15eedd921efbc4d1bdf6fcf6202b9a58b403f6f805"
-
-[[package]]
-name = "language-tags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -3332,23 +3047,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
-name = "local-channel"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a493488de5f18c8ffcba89eebb8532ffc562dc400490eb65b84893fae0b178"
-dependencies = [
- "futures-core",
- "futures-sink",
- "local-waker",
-]
-
-[[package]]
-name = "local-waker"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
-
-[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3468,7 +3166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
@@ -3994,12 +3691,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
 name = "pct-str"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4257,29 +3948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.37",
 ]
 
 [[package]]
@@ -4693,18 +4361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pemfile"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5040,17 +4696,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -6717,34 +6362,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
-]
-
-[[package]]
-name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ resolver = "2"
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
 env_logger = "0.10.0"
-expect-patch = {path = "./expect-patch/"}
-keramik-common = { path = "./common/" }
+expect-patch = { path = "./expect-patch/" }
+keramik-common = { path = "./common/", default-features = false }
 multiaddr = "0.17"
 multibase = "0.9.1"
 multihash = "0.17"

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
+CARGO = CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTFLAGS="-D warnings" cargo
+
 .PHONY: all
 all: build check-fmt check-clippy test
 
 .PHONY: test
 test:
 	# Test with default features
-	cargo test --locked
+	${CARGO} test --locked
 	# Test with all features
-	cargo test --locked --all-features
+	${CARGO} test --locked --all-features
+	# Test without default features
+	${CARGO} test --locked --no-default-features
 
 .PHONY: check-fmt
 check-fmt:
@@ -15,17 +19,17 @@ check-fmt:
 .PHONY: check-clippy
 check-clippy:
 	# Check with default features
-	cargo clippy --workspace --all-targets -- -D warnings
+	${CARGO} clippy --workspace --all-targets
 	# Check with all features
-	cargo clippy --workspace --all-targets --all-features -- -D warnings
+	${CARGO} clippy --workspace --all-targets --all-features
 
 .PHONY: build
 build: runner operator
 
 .PHONY: runner
 runner:
-	CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTFLAGS="-D warnings" cargo build --bin keramik-runner --release --locked  --config net.git-fetch-with-cli=true
+	${CARGO} build --bin keramik-runner --release --locked  --config net.git-fetch-with-cli=true
 
 .PHONY: operator
 operator:
-	CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTFLAGS="-D warnings" cargo build --bin keramik-operator --release --locked  --config net.git-fetch-with-cli=true
+	${CARGO} build --bin keramik-operator --release --locked  --config net.git-fetch-with-cli=true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -4,18 +4,23 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+telemetry = [
+    "opentelemetry",
+    "opentelemetry-otlp",
+    "tracing-opentelemetry",
+    "tracing-subscriber",
+    "tracing",
+]
 
 [dependencies]
-actix-web = "4.3.1"
 anyhow.workspace = true
 gethostname = "0.4.2"
-opentelemetry-otlp.workspace = true
-opentelemetry.workspace = true
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
 schemars.workspace = true
 serde.workspace = true
-serde_json.workspace = true
-tokio.workspace = true
-tonic.workspace = true
-tracing-opentelemetry.workspace = true
-tracing-subscriber.workspace = true
-tracing.workspace = true
+tracing-opentelemetry = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,4 +1,5 @@
 //! Provides types and functions that common to both the runner and operator.
 #![deny(missing_docs)]
 pub mod peer_info;
+#[cfg(feature = "telemetry")]
 pub mod telemetry;

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -1,11 +1,38 @@
-
 [[bin]]
 path = "src/crdgen.rs"
 name = "crdgen"
+required-features = ["crdgen"]
 
 [[bin]]
 path = "src/main.rs"
 name = "keramik-operator"
+required-features = ["controller"]
+
+
+[features]
+default = ["controller", "crdgen"]
+crdgen = ["dep:serde_yaml"]
+controller = [
+    "dep:anyhow",
+    "dep:async-trait",
+    "dep:clap",
+    "dep:futures",
+    "dep:hex",
+    "dep:multiaddr",
+    "dep:multibase",
+    "dep:multihash",
+    "dep:opentelemetry",
+    "dep:reqwest",
+    "dep:serde_yaml",
+    "dep:thiserror",
+    "dep:tokio",
+    "dep:tracing",
+    "dep:tracing-log",
+    # Enable keramik-common/telemetry feature if the controller is enabled.
+    "keramik-common/telemetry",
+    "kube/client",
+]
+
 
 [package]
 name = "keramik-operator"
@@ -14,14 +41,11 @@ version = "0.0.1"
 description = "K8s operator binary for automating Ceramic networks"
 
 [dependencies]
-async-trait = "0.1.68"
-futures = "0.3"
-hex = "0.4.3"
-rand = "0.8.5"
-serde_yaml = "0.9.21"
-thiserror = "1"
-anyhow.workspace = true
-clap.workspace = true
+anyhow = { workspace = true, optional = true }
+async-trait = { version = "0.1.68", optional = true }
+clap = { workspace = true, optional = true }
+futures = { version = "0.3", optional = true }
+hex = { version = "0.4.3", optional = true }
 k8s-openapi = { version = "0.20", features = [
     "v1_26",
     "schemars",
@@ -30,23 +54,21 @@ keramik-common.workspace = true
 kube = { version = "0.86", features = [
     "derive",
     "runtime",
-], default-features = true }
-multiaddr.workspace = true
-multibase.workspace = true
-multihash.workspace = true
-opentelemetry.workspace = true
-opentelemetry-otlp.workspace = true
-reqwest.workspace = true
+], default-features = false }
+multiaddr = { workspace = true, optional = true }
+multibase = { workspace = true, optional = true }
+multihash = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+rand = { version = "0.8.5" }
+reqwest = { workspace = true, optional = true }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
-tonic.workspace = true
-tracing.workspace = true
-tracing-log.workspace = true
-tracing-opentelemetry.workspace = true
-tracing-subscriber.workspace = true
-
+serde_yaml = { version = "0.9.21", optional = true }
+thiserror = { version = "1", optional = true }
+tokio = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+tracing-log = { workspace = true, optional = true }
 
 [dev-dependencies]
 expect-patch.workspace = true

--- a/operator/src/labels.rs
+++ b/operator/src/labels.rs
@@ -1,0 +1,20 @@
+use std::collections::BTreeMap;
+
+/// Create lables that can be used as a unique selector for a given app name.
+pub fn selector_labels(app: &str) -> Option<BTreeMap<String, String>> {
+    Some(BTreeMap::from_iter(vec![(
+        "app".to_owned(),
+        app.to_owned(),
+    )]))
+}
+
+/// Manage by label
+pub const MANAGED_BY_LABEL_SELECTOR: &str = "managed-by=keramik";
+
+/// Labels that indicate the resource is managed by the keramik operator.
+pub fn managed_labels() -> Option<BTreeMap<String, String>> {
+    Some(BTreeMap::from_iter(vec![(
+        "managed-by".to_owned(),
+        "keramik".to_owned(),
+    )]))
+}

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -1,6 +1,15 @@
 //! Provides API for the operator and related tooling.
-#![deny(missing_docs)]
+#![warn(missing_docs)]
+
+#[cfg(feature = "controller")]
+pub(crate) mod labels;
+#[cfg(feature = "controller")]
 pub mod monitoring;
 pub mod network;
 pub mod simulation;
+#[cfg(feature = "controller")]
 pub mod utils;
+
+/// A list of constants used in various K8s resources
+#[cfg(feature = "controller")]
+const CONTROLLER_NAME: &str = "keramik";

--- a/operator/src/monitoring/jaeger.rs
+++ b/operator/src/monitoring/jaeger.rs
@@ -14,7 +14,7 @@ use k8s_openapi::{
     },
 };
 
-use crate::utils::selector_labels;
+use crate::labels::selector_labels;
 
 pub const JAEGER_APP: &str = "jaeger";
 

--- a/operator/src/monitoring/opentelemetry.rs
+++ b/operator/src/monitoring/opentelemetry.rs
@@ -17,7 +17,7 @@ use k8s_openapi::{
     },
 };
 
-use crate::utils::selector_labels;
+use crate::labels::selector_labels;
 
 use crate::simulation::controller::{OTEL_ACCOUNT, OTEL_CONFIG_MAP_NAME, OTEL_CR};
 

--- a/operator/src/monitoring/prometheus.rs
+++ b/operator/src/monitoring/prometheus.rs
@@ -15,7 +15,7 @@ use k8s_openapi::{
 
 use crate::simulation::controller::PROM_CONFIG_MAP_NAME;
 
-use crate::utils::selector_labels;
+use crate::labels::selector_labels;
 
 pub const PROM_APP: &str = "prometheus";
 

--- a/operator/src/network/bootstrap.rs
+++ b/operator/src/network/bootstrap.rs
@@ -4,24 +4,8 @@ use k8s_openapi::api::{
         ConfigMapVolumeSource, Container, EnvVar, PodSpec, PodTemplateSpec, Volume, VolumeMount,
     },
 };
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
-use crate::network::controller::PEERS_CONFIG_MAP_NAME;
-
-/// BootstrapSpec defines how the network bootstrap process should proceed.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct BootstrapSpec {
-    /// Image of the runner for the bootstrap job.
-    pub image: Option<String>,
-    /// Image pull policy for the bootstrap job.
-    pub image_pull_policy: Option<String>,
-    /// Bootstrap method. Defaults to ring.
-    pub method: Option<String>,
-    /// Number of nodes to connect to each peer.
-    pub n: Option<i32>,
-}
+use crate::network::{BootstrapSpec, PEERS_CONFIG_MAP_NAME};
 
 // BootstrapConfig defines which properties of the JobSpec can be customized.
 pub struct BootstrapConfig {

--- a/operator/src/network/cas.rs
+++ b/operator/src/network/cas.rs
@@ -15,43 +15,18 @@ use k8s_openapi::{
     },
 };
 use kube::core::ObjectMeta;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
-use crate::{
-    network::{
-        controller::{
-            CAS_APP, CAS_IPFS_APP, CAS_IPFS_SERVICE_NAME, CAS_POSTGRES_APP,
-            CAS_POSTGRES_SERVICE_NAME, CAS_SERVICE_NAME, GANACHE_APP, GANACHE_SERVICE_NAME,
-            LOCALSTACK_APP, LOCALSTACK_SERVICE_NAME,
-        },
-        datadog::DataDogConfig,
-        utils::{ResourceLimitsConfig, ResourceLimitsSpec},
+use crate::labels::{managed_labels, selector_labels};
+use crate::network::{resource_limits::ResourceLimitsConfig, CasSpec};
+
+use crate::network::{
+    controller::{
+        CAS_APP, CAS_IPFS_APP, CAS_IPFS_SERVICE_NAME, CAS_POSTGRES_APP, CAS_POSTGRES_SERVICE_NAME,
+        CAS_SERVICE_NAME, GANACHE_APP, GANACHE_SERVICE_NAME, LOCALSTACK_APP,
+        LOCALSTACK_SERVICE_NAME,
     },
-    utils::managed_labels,
+    datadog::DataDogConfig,
 };
-
-use crate::utils::selector_labels;
-
-/// Defines details about how CAS is deployed
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct CasSpec {
-    /// Image of the runner for the bootstrap job.
-    pub image: Option<String>,
-    /// Image pull policy for the bootstrap job.
-    pub image_pull_policy: Option<String>,
-    /// Resource limits for the CAS pod, applies to both requests and limits.
-    pub cas_resource_limits: Option<ResourceLimitsSpec>,
-    /// Resource limits for the CAS IPFS pod, applies to both requests and limits.
-    pub ipfs_resource_limits: Option<ResourceLimitsSpec>,
-    /// Resource limits for the Ganache pod, applies to both requests and limits.
-    pub ganache_resource_limits: Option<ResourceLimitsSpec>,
-    /// Resource limits for the CAS Postgres pod, applies to both requests and limits.
-    pub postgres_resource_limits: Option<ResourceLimitsSpec>,
-    /// Resource limits for the LocalStack pod, applies to both requests and limits.
-    pub localstack_resource_limits: Option<ResourceLimitsSpec>,
-}
 
 pub struct CasConfig {
     pub image: String,

--- a/operator/src/network/datadog.rs
+++ b/operator/src/network/datadog.rs
@@ -1,17 +1,8 @@
 use std::collections::BTreeMap;
 
 use k8s_openapi::api::core::v1::{EnvVar, EnvVarSource, ObjectFieldSelector};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
-/// Describes if and how to configure datadog telemetry
-#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct DataDogSpec {
-    pub enabled: Option<bool>,
-    pub version: Option<String>,
-    pub profiling_enabled: Option<bool>,
-}
+use crate::network::DataDogSpec;
 
 /// Describes if and how to configure datadog telemetry
 pub struct DataDogConfig {

--- a/operator/src/network/mod.rs
+++ b/operator/src/network/mod.rs
@@ -1,78 +1,35 @@
 //! Network is k8s custom resource that defines a Ceramic network.
+
+// Export all spec types
+mod spec;
+pub use spec::*;
+
+// All other mods are behind the controller flag to keep the deps to a minimum
+#[cfg(feature = "controller")]
 pub(crate) mod bootstrap;
+#[cfg(feature = "controller")]
 pub(crate) mod cas;
+#[cfg(feature = "controller")]
 pub(crate) mod ceramic;
+#[cfg(feature = "controller")]
 pub(crate) mod controller;
+#[cfg(feature = "controller")]
 pub(crate) mod datadog;
+#[cfg(feature = "controller")]
+pub(crate) mod ipfs_rpc;
+#[cfg(feature = "controller")]
 pub(crate) mod peers;
-pub(crate) mod utils;
+#[cfg(feature = "controller")]
+pub(crate) mod resource_limits;
 
 #[cfg(test)]
+#[cfg(feature = "controller")]
 pub mod stub;
 
-use crate::network::{cas::CasSpec, datadog::DataDogSpec};
 // Expose Context for testing
 #[cfg(test)]
+#[cfg(feature = "controller")]
 pub use crate::utils::Context;
 
-pub use bootstrap::BootstrapSpec;
-pub use ceramic::{CeramicSpec, GoIpfsSpec, IpfsSpec, RustIpfsSpec};
-pub use controller::run;
-
-use keramik_common::peer_info::Peer;
-use kube::CustomResource;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
-/// Primary CRD for creating and managing a Ceramic network.
-#[derive(CustomResource, Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
-#[kube(
-    group = "keramik.3box.io",
-    version = "v1alpha1",
-    kind = "Network",
-    plural = "networks",
-    status = "NetworkStatus",
-    derive = "PartialEq"
-)]
-#[serde(rename_all = "camelCase")]
-pub struct NetworkSpec {
-    /// Number of Ceramic peers
-    pub replicas: i32,
-    ///  Describes how new peers in the network should be bootstrapped.
-    pub bootstrap: Option<BootstrapSpec>,
-    /// Describes how each peer should behave.
-    /// Multiple ceramic specs can be defined.
-    /// Total replicas will be split across each ceramic spec according to relative weights.
-    /// It is possible that if the weight is small enough compared to others that a single spec
-    /// will be assigned zero replicas.
-    pub ceramic: Vec<CeramicSpec>,
-    /// Name of secret containing the private key used for signing anchor requests and generating
-    /// the Admin DID.
-    pub private_key_secret: Option<String>,
-    /// Ceramic network type
-    pub network_type: Option<String>,
-    /// PubSub topic for Ceramic nodes to use
-    pub pubsub_topic: Option<String>,
-    /// Ethereum RPC URL for Ceramic nodes to use for verifying anchors
-    pub eth_rpc_url: Option<String>,
-    /// URL for Ceramic Anchor Service (CAS)
-    pub cas_api_url: Option<String>,
-    /// Describes how CAS should be deployed.
-    pub cas: Option<CasSpec>,
-    /// Descibes if/how datadog should be deployed.
-    pub datadog: Option<DataDogSpec>,
-}
-
-/// Current status of the network.
-#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct NetworkStatus {
-    /// Number of Ceramic peers
-    pub replicas: i32,
-    ///  Describes how new peers in the network should be bootstrapped.
-    pub ready_replicas: i32,
-    /// K8s namespace this network is deployed in
-    pub namespace: Option<String>,
-    /// Information about each Ceramic peer
-    pub peers: Vec<Peer>,
-}
+#[cfg(feature = "controller")]
+pub use controller::{run, PEERS_CONFIG_MAP_NAME};

--- a/operator/src/network/resource_limits.rs
+++ b/operator/src/network/resource_limits.rs
@@ -1,0 +1,39 @@
+use std::collections::BTreeMap;
+
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+
+use crate::network::ResourceLimitsSpec;
+
+#[derive(Clone)]
+pub struct ResourceLimitsConfig {
+    /// Cpu resource limit
+    pub cpu: Quantity,
+    /// Memory resource limit
+    pub memory: Quantity,
+    // Ephemeral storage resource limit
+    pub storage: Quantity,
+}
+
+impl ResourceLimitsConfig {
+    pub fn from_spec(spec: Option<ResourceLimitsSpec>, defaults: Self) -> Self {
+        if let Some(spec) = spec {
+            Self {
+                cpu: spec.cpu.unwrap_or(defaults.cpu),
+                memory: spec.memory.unwrap_or(defaults.memory),
+                storage: spec.storage.unwrap_or(defaults.storage),
+            }
+        } else {
+            defaults
+        }
+    }
+}
+
+impl From<ResourceLimitsConfig> for BTreeMap<String, Quantity> {
+    fn from(value: ResourceLimitsConfig) -> Self {
+        BTreeMap::from_iter([
+            ("cpu".to_owned(), value.cpu),
+            ("ephemeral-storage".to_owned(), value.storage),
+            ("memory".to_owned(), value.memory),
+        ])
+    }
+}

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -1,0 +1,174 @@
+//! Place all spec types into a single module so they can be used as a lightweight dependency
+
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use keramik_common::peer_info::Peer;
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Primary CRD for creating and managing a Ceramic network.
+#[derive(CustomResource, Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
+#[kube(
+    group = "keramik.3box.io",
+    version = "v1alpha1",
+    kind = "Network",
+    plural = "networks",
+    status = "NetworkStatus",
+    derive = "PartialEq"
+)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkSpec {
+    /// Number of Ceramic peers
+    pub replicas: i32,
+    ///  Describes how new peers in the network should be bootstrapped.
+    pub bootstrap: Option<BootstrapSpec>,
+    /// Describes how each peer should behave.
+    /// Multiple ceramic specs can be defined.
+    /// Total replicas will be split across each ceramic spec according to relative weights.
+    /// It is possible that if the weight is small enough compared to others that a single spec
+    /// will be assigned zero replicas.
+    pub ceramic: Vec<CeramicSpec>,
+    /// Name of secret containing the private key used for signing anchor requests and generating
+    /// the Admin DID.
+    pub private_key_secret: Option<String>,
+    /// Ceramic network type
+    pub network_type: Option<String>,
+    /// PubSub topic for Ceramic nodes to use
+    pub pubsub_topic: Option<String>,
+    /// Ethereum RPC URL for Ceramic nodes to use for verifying anchors
+    pub eth_rpc_url: Option<String>,
+    /// URL for Ceramic Anchor Service (CAS)
+    pub cas_api_url: Option<String>,
+    /// Describes how CAS should be deployed.
+    pub cas: Option<CasSpec>,
+    /// Descibes if/how datadog should be deployed.
+    pub datadog: Option<DataDogSpec>,
+}
+
+/// Current status of the network.
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkStatus {
+    /// Number of Ceramic peers
+    pub replicas: i32,
+    ///  Describes how new peers in the network should be bootstrapped.
+    pub ready_replicas: i32,
+    /// K8s namespace this network is deployed in
+    pub namespace: Option<String>,
+    /// Information about each Ceramic peer
+    pub peers: Vec<Peer>,
+}
+
+/// BootstrapSpec defines how the network bootstrap process should proceed.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct BootstrapSpec {
+    /// Image of the runner for the bootstrap job.
+    pub image: Option<String>,
+    /// Image pull policy for the bootstrap job.
+    pub image_pull_policy: Option<String>,
+    /// Bootstrap method. Defaults to ring.
+    pub method: Option<String>,
+    /// Number of nodes to connect to each peer.
+    pub n: Option<i32>,
+}
+
+/// Describes how a Ceramic peer should behave.
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CeramicSpec {
+    /// Relative weight of the spec compared to others.
+    pub weight: Option<i32>,
+    /// Name of a config map with a ceramic-init.sh script that runs as an initialization step.
+    pub init_config_map: Option<String>,
+    /// Image of the ceramic container.
+    pub image: Option<String>,
+    /// Pull policy for the ceramic container image.
+    pub image_pull_policy: Option<String>,
+    /// Configuration of the IPFS container
+    pub ipfs: Option<IpfsSpec>,
+    /// Resource limits for ceramic nodes, applies to both requests and limits.
+    pub resource_limits: Option<ResourceLimitsSpec>,
+}
+
+/// Describes how the IPFS node for a peer should behave.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum IpfsSpec {
+    /// Rust IPFS specification
+    Rust(RustIpfsSpec),
+    /// Go IPFS specification
+    Go(GoIpfsSpec),
+}
+
+/// Describes how the Rust IPFS node for a peer should behave.
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RustIpfsSpec {
+    /// Name of image to use
+    pub image: Option<String>,
+    /// Image pull policy for the image
+    pub image_pull_policy: Option<String>,
+    /// Resource limits for ipfs nodes, applies to both requests and limits.
+    pub resource_limits: Option<ResourceLimitsSpec>,
+    /// Value of the RUST_LOG env var.
+    pub rust_log: Option<String>,
+}
+
+/// Describes how the Go IPFS node for a peer should behave.
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GoIpfsSpec {
+    /// Name of image to use
+    pub image: Option<String>,
+    /// Image pull policy for the image
+    pub image_pull_policy: Option<String>,
+    /// Resource limits for ipfs nodes, applies to both requests and limits.
+    pub resource_limits: Option<ResourceLimitsSpec>,
+    /// List of ipfs commands to run during initialization.
+    pub commands: Option<Vec<String>>,
+}
+
+/// Defines details about how CAS is deployed
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CasSpec {
+    /// Image of the runner for the bootstrap job.
+    pub image: Option<String>,
+    /// Image pull policy for the bootstrap job.
+    pub image_pull_policy: Option<String>,
+    /// Resource limits for the CAS pod, applies to both requests and limits.
+    pub cas_resource_limits: Option<ResourceLimitsSpec>,
+    /// Resource limits for the CAS IPFS pod, applies to both requests and limits.
+    pub ipfs_resource_limits: Option<ResourceLimitsSpec>,
+    /// Resource limits for the Ganache pod, applies to both requests and limits.
+    pub ganache_resource_limits: Option<ResourceLimitsSpec>,
+    /// Resource limits for the CAS Postgres pod, applies to both requests and limits.
+    pub postgres_resource_limits: Option<ResourceLimitsSpec>,
+    /// Resource limits for the LocalStack pod, applies to both requests and limits.
+    pub localstack_resource_limits: Option<ResourceLimitsSpec>,
+}
+
+/// Describes if and how to configure datadog telemetry
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DataDogSpec {
+    /// When true datadog telemetry will be collected.
+    pub enabled: Option<bool>,
+    /// Version of the DataDog agent.
+    pub version: Option<String>,
+    /// When true profiles will be collected.
+    pub profiling_enabled: Option<bool>,
+}
+
+/// Describes the resources limits and requests for a pod
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceLimitsSpec {
+    /// Cpu resource limit
+    pub cpu: Option<Quantity>,
+    /// Memory resource limit
+    pub memory: Option<Quantity>,
+    /// Ephemeral storage resource limit
+    pub storage: Option<Quantity>,
+}

--- a/operator/src/network/stub.rs
+++ b/operator/src/network/stub.rs
@@ -5,11 +5,9 @@ use expect_test::{expect_file, ExpectFile};
 use k8s_openapi::api::{apps::v1::StatefulSetSpec, batch::v1::Job, core::v1::Secret};
 
 use crate::{
+    labels::managed_labels,
     network::{Network, NetworkSpec, NetworkStatus},
-    utils::{
-        managed_labels,
-        test::{ApiServerVerifier, WithStatus},
-    },
+    utils::test::{ApiServerVerifier, WithStatus},
 };
 
 // Add tests specific implementation to the Network

--- a/operator/src/simulation/job.rs
+++ b/operator/src/simulation/job.rs
@@ -1,0 +1,32 @@
+use crate::simulation::SimulationSpec;
+
+/// Configuration for job images.
+#[derive(Clone, Debug)]
+pub struct JobImageConfig {
+    /// Image for all jobs created by the simulation.
+    pub image: String,
+    /// Pull policy for image.
+    pub image_pull_policy: String,
+}
+
+impl Default for JobImageConfig {
+    fn default() -> Self {
+        Self {
+            image: "public.ecr.aws/r5b3e0r5/3box/keramik-runner:latest".to_owned(),
+            image_pull_policy: "Always".to_owned(),
+        }
+    }
+}
+
+impl From<&SimulationSpec> for JobImageConfig {
+    fn from(value: &SimulationSpec) -> Self {
+        let default = Self::default();
+        Self {
+            image: value.image.to_owned().unwrap_or(default.image),
+            image_pull_policy: value
+                .image_pull_policy
+                .to_owned()
+                .unwrap_or(default.image_pull_policy),
+        }
+    }
+}

--- a/operator/src/simulation/manager.rs
+++ b/operator/src/simulation/manager.rs
@@ -9,7 +9,7 @@ use k8s_openapi::api::{
 };
 use kube::core::ObjectMeta;
 
-use crate::{network::controller::PEERS_CONFIG_MAP_NAME, simulation::JobImageConfig};
+use crate::{network::PEERS_CONFIG_MAP_NAME, simulation::job::JobImageConfig};
 
 pub fn service_spec() -> ServiceSpec {
     ServiceSpec {

--- a/operator/src/simulation/mod.rs
+++ b/operator/src/simulation/mod.rs
@@ -1,86 +1,24 @@
 //! Simulation is a k8s custom resource that defines a Ceramic simulation.
+
+// Export all spec types
+mod spec;
+pub use spec::*;
+
+// All other mods are behind the controller flag to keep the deps to a minimum
+#[cfg(feature = "controller")]
 pub(crate) mod controller;
+#[cfg(feature = "controller")]
+pub(crate) mod job;
+#[cfg(feature = "controller")]
 pub(crate) mod manager;
+#[cfg(feature = "controller")]
 pub(crate) mod redis;
-#[cfg(test)]
-pub mod stub;
+#[cfg(feature = "controller")]
 pub(crate) mod worker;
 
+#[cfg(test)]
+#[cfg(feature = "controller")]
+pub mod stub;
+
+#[cfg(feature = "controller")]
 pub use controller::run;
-
-use kube::CustomResource;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
-use rand::random;
-
-/// Primary CRD for creating and managing a Ceramic Simulation.
-#[derive(CustomResource, Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
-#[kube(
-    group = "keramik.3box.io",
-    version = "v1alpha1",
-    kind = "Simulation",
-    plural = "simulations",
-    status = "SimulationStatus",
-    derive = "PartialEq",
-    namespaced
-)]
-#[serde(rename_all = "camelCase")]
-pub struct SimulationSpec {
-    /// Simulation runner scenario
-    pub scenario: String,
-    /// Number of users
-    pub users: u32,
-    /// Time to run simulation
-    pub run_time: u32,
-    /// Image for all jobs created by the simulation.
-    pub image: Option<String>,
-    /// Pull policy for image.
-    pub image_pull_policy: Option<String>,
-}
-
-/// Current status of a simulation.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct SimulationStatus {
-    nonce: u32,
-}
-
-impl Default for SimulationStatus {
-    fn default() -> SimulationStatus {
-        SimulationStatus {
-            nonce: random::<u32>(),
-        }
-    }
-}
-
-/// Configuration for job images.
-#[derive(Clone, Debug)]
-pub struct JobImageConfig {
-    /// Image for all jobs created by the simulation.
-    pub image: String,
-    /// Pull policy for image.
-    pub image_pull_policy: String,
-}
-
-impl Default for JobImageConfig {
-    fn default() -> Self {
-        Self {
-            image: "public.ecr.aws/r5b3e0r5/3box/keramik-runner:latest".to_owned(),
-            image_pull_policy: "Always".to_owned(),
-        }
-    }
-}
-
-impl From<&SimulationSpec> for JobImageConfig {
-    fn from(value: &SimulationSpec) -> Self {
-        let default = Self::default();
-        Self {
-            image: value.image.to_owned().unwrap_or(default.image),
-            image_pull_policy: value
-                .image_pull_policy
-                .to_owned()
-                .unwrap_or(default.image_pull_policy),
-        }
-    }
-}

--- a/operator/src/simulation/redis.rs
+++ b/operator/src/simulation/redis.rs
@@ -14,7 +14,7 @@ use k8s_openapi::{
     },
 };
 
-use crate::utils::{managed_labels, selector_labels};
+use crate::labels::{managed_labels, selector_labels};
 
 pub const REDIS_APP: &str = "redis";
 

--- a/operator/src/simulation/spec.rs
+++ b/operator/src/simulation/spec.rs
@@ -1,0 +1,37 @@
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Primary CRD for creating and managing a Ceramic Simulation.
+#[derive(CustomResource, Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
+#[kube(
+    group = "keramik.3box.io",
+    version = "v1alpha1",
+    kind = "Simulation",
+    plural = "simulations",
+    status = "SimulationStatus",
+    derive = "PartialEq",
+    namespaced
+)]
+#[serde(rename_all = "camelCase")]
+pub struct SimulationSpec {
+    /// Simulation runner scenario
+    pub scenario: String,
+    /// Number of users
+    pub users: u32,
+    /// Time to run simulation
+    pub run_time: u32,
+    /// Image for all jobs created by the simulation.
+    pub image: Option<String>,
+    /// Pull policy for image.
+    pub image_pull_policy: Option<String>,
+}
+
+/// Current status of a simulation.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SimulationStatus {
+    /// Unique value for this simulation.
+    /// Used to enable determisitically psuedo-random values during any simulation logic.
+    pub nonce: u32,
+}

--- a/operator/src/simulation/worker.rs
+++ b/operator/src/simulation/worker.rs
@@ -9,7 +9,7 @@ use k8s_openapi::api::{
 
 use kube::core::ObjectMeta;
 
-use crate::{network::controller::PEERS_CONFIG_MAP_NAME, simulation::JobImageConfig};
+use crate::{network::PEERS_CONFIG_MAP_NAME, simulation::job::JobImageConfig};
 
 // WorkerConfig defines which properties of the JobSpec can be customized.
 pub struct WorkerConfig {

--- a/operator/src/utils/mod.rs
+++ b/operator/src/utils/mod.rs
@@ -16,7 +16,7 @@ use k8s_openapi::{
     apimachinery::pkg::apis::meta::v1::OwnerReference,
 };
 
-use crate::network::utils::IpfsRpcClient;
+use crate::{labels::managed_labels, network::ipfs_rpc::IpfsRpcClient, CONTROLLER_NAME};
 
 use kube::{
     api::{DeleteParams, Patch, PatchParams},
@@ -51,28 +51,6 @@ impl<R> Context<R, StdRng> {
             rng: Mutex::new(StdRng::from_rng(thread_rng())?),
         })
     }
-}
-
-/// A list of constants used in various K8s resources
-pub const CONTROLLER_NAME: &str = "keramik";
-
-/// Create lables that can be used as a unique selector for a given app name.
-pub fn selector_labels(app: &str) -> Option<BTreeMap<String, String>> {
-    Some(BTreeMap::from_iter(vec![(
-        "app".to_owned(),
-        app.to_owned(),
-    )]))
-}
-
-/// Manage by label
-pub const MANAGED_BY_LABEL_SELECTOR: &str = "managed-by=keramik";
-
-/// Labels that indicate the resource is managed by the keramik operator.
-pub fn managed_labels() -> Option<BTreeMap<String, String>> {
-    Some(BTreeMap::from_iter(vec![(
-        "managed-by".to_owned(),
-        "keramik".to_owned(),
-    )]))
 }
 
 /// Apply a Service

--- a/operator/src/utils/test.rs
+++ b/operator/src/utils/test.rs
@@ -9,7 +9,7 @@ use rand::rngs::mock::StepRng;
 use reqwest::header::HeaderMap;
 use serde::{Deserialize, Serialize};
 
-use crate::{network::utils::IpfsRpcClient, utils::Context};
+use crate::{network::ipfs_rpc::IpfsRpcClient, utils::Context};
 
 pub type ApiServerHandle = tower_test::mock::Handle<http::Request<Body>, http::Response<Body>>;
 

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -13,14 +13,10 @@ ceramic-http-client = { git = "https://github.com/3box/ceramic-http-client-rs.gi
 cid = "0.9"
 clap.workspace = true
 goose = { version = "0.16", features = ["gaggle"] }
-keramik-common.workspace = true
+keramik-common = { workspace = true, features = ["telemetry"] }
 libipld = "0.16.0"
-multiaddr.workspace = true
-multibase.workspace = true
 multihash.workspace = true
-opentelemetry-otlp.workspace = true
 opentelemetry.workspace = true
-prometheus-client = "0.19"
 rand = "0.8.5"
 redis = { version = "0.23.2", features = ["tokio-comp"] }
 reqwest.workspace = true
@@ -28,8 +24,5 @@ schemars = "0.8.12"
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-tonic.workspace = true
 tracing-log.workspace = true
-tracing-opentelemetry.workspace = true
-tracing-subscriber.workspace = true
 tracing.workspace = true


### PR DESCRIPTION
With this change when you use keramik-operator as a dependency without its default features you get a crate that only contains the spec types with minimal deps.