### PR TITLE
feat: add network TTL

### DIFF
--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -1,3 +1,9 @@
+[package]
+name = "keramik-operator"
+edition = "2021"
+version = "0.0.1"
+description = "K8s operator binary for automating Ceramic networks"
+
 [[bin]]
 path = "src/crdgen.rs"
 name = "crdgen"
@@ -33,12 +39,6 @@ controller = [
     "kube/client",
 ]
 
-
-[package]
-name = "keramik-operator"
-edition = "2021"
-version = "0.0.1"
-description = "K8s operator binary for automating Ceramic networks"
 
 [dependencies]
 anyhow = { workspace = true, optional = true }

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -43,6 +43,9 @@ pub struct NetworkSpec {
     pub cas: Option<CasSpec>,
     /// Descibes if/how datadog should be deployed.
     pub datadog: Option<DataDogSpec>,
+    /// The number of seconds this network should live.
+    /// If unset the network lives forever.
+    pub ttl_seconds: Option<u64>,
 }
 
 /// Current status of the network.
@@ -57,6 +60,9 @@ pub struct NetworkStatus {
     pub namespace: Option<String>,
     /// Information about each Ceramic peer
     pub peers: Vec<Peer>,
+    /// Time when the network will expire and be deleted.
+    /// If unset the network lives forever.
+    pub expiration_time: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::Time>,
 }
 
 /// BootstrapSpec defines how the network bootstrap process should proceed.

--- a/operator/src/network/testdata/ceramics_weighted_status
+++ b/operator/src/network/testdata/ceramics_weighted_status
@@ -178,7 +178,8 @@ Request {
               "p2pAddrs": []
             }
           }
-        ]
+        ],
+        "expirationTime": null
       }
     },
 }

--- a/operator/src/network/testdata/delete_network
+++ b/operator/src/network/testdata/delete_network
@@ -1,0 +1,8 @@
+Request {
+    method: "DELETE",
+    uri: "/apis/keramik.3box.io/v1alpha1/networks/test?",
+    headers: {
+        "content-type": "application/json",
+    },
+    body: {},
+}

--- a/operator/src/network/testdata/not_expired_status
+++ b/operator/src/network/testdata/not_expired_status
@@ -11,7 +11,7 @@ Request {
         "readyReplicas": 0,
         "namespace": null,
         "peers": [],
-        "expirationTime": null
+        "expirationTime": "2023-10-11T09:40:00Z"
       }
     },
 }

--- a/operator/src/simulation/controller.rs
+++ b/operator/src/simulation/controller.rs
@@ -31,6 +31,7 @@ use crate::{
         job::JobImageConfig, manager, manager::ManagerConfig, redis, worker, worker::WorkerConfig,
         Simulation, SimulationStatus,
     },
+    utils::Clock,
 };
 
 use crate::monitoring::{jaeger, opentelemetry, prometheus};
@@ -52,7 +53,7 @@ use crate::utils::{
 fn on_error(
     _network: Arc<Simulation>,
     _error: &Error,
-    _context: Arc<Context<impl IpfsRpcClient, impl RngCore>>,
+    _context: Arc<Context<impl IpfsRpcClient, impl RngCore, impl Clock>>,
 ) -> Action {
     Action::requeue(Duration::from_secs(5))
 }
@@ -130,7 +131,7 @@ pub async fn run() {
 /// Perform a reconile pass for the Simulation CRD
 async fn reconcile(
     simulation: Arc<Simulation>,
-    cx: Arc<Context<impl IpfsRpcClient, impl RngCore>>,
+    cx: Arc<Context<impl IpfsRpcClient, impl RngCore, impl Clock>>,
 ) -> Result<Action, Error> {
     let spec = simulation.spec();
     debug!(?spec, "reconcile");
@@ -221,7 +222,7 @@ pub const OTEL_CONFIG_MAP_NAME: &str = "otel-config";
 pub const PROM_CONFIG_MAP_NAME: &str = "prom-config";
 
 async fn apply_manager(
-    cx: Arc<Context<impl IpfsRpcClient, impl RngCore>>,
+    cx: Arc<Context<impl IpfsRpcClient, impl RngCore, impl Clock>>,
     ns: &str,
     simulation: Arc<Simulation>,
     config: ManagerConfig,
@@ -252,7 +253,7 @@ async fn apply_manager(
 }
 
 async fn get_num_peers(
-    cx: Arc<Context<impl IpfsRpcClient, impl RngCore>>,
+    cx: Arc<Context<impl IpfsRpcClient, impl RngCore, impl Clock>>,
     ns: &str,
 ) -> Result<u32, kube::error::Error> {
     let config_maps: Api<ConfigMap> = Api::namespaced(cx.k_client.clone(), ns);
@@ -270,7 +271,7 @@ async fn get_num_peers(
 }
 
 async fn redis_ready(
-    cx: Arc<Context<impl IpfsRpcClient, impl RngCore>>,
+    cx: Arc<Context<impl IpfsRpcClient, impl RngCore, impl Clock>>,
     ns: &str,
 ) -> Result<bool, kube::error::Error> {
     let stateful_sets: Api<StatefulSet> = Api::namespaced(cx.k_client.clone(), ns);
@@ -285,7 +286,7 @@ async fn redis_ready(
 }
 
 async fn monitoring_ready(
-    cx: Arc<Context<impl IpfsRpcClient, impl RngCore>>,
+    cx: Arc<Context<impl IpfsRpcClient, impl RngCore, impl Clock>>,
     ns: &str,
 ) -> Result<bool, kube::error::Error> {
     let stateful_sets: Api<StatefulSet> = Api::namespaced(cx.k_client.clone(), ns);
@@ -310,7 +311,7 @@ async fn monitoring_ready(
 }
 
 async fn apply_n_workers(
-    cx: Arc<Context<impl IpfsRpcClient, impl RngCore>>,
+    cx: Arc<Context<impl IpfsRpcClient, impl RngCore, impl Clock>>,
     ns: &str,
     peers: u32,
     nonce: u32,
@@ -345,7 +346,7 @@ async fn apply_n_workers(
 }
 
 async fn apply_redis(
-    cx: Arc<Context<impl IpfsRpcClient, impl RngCore>>,
+    cx: Arc<Context<impl IpfsRpcClient, impl RngCore, impl Clock>>,
     ns: &str,
     simulation: Arc<Simulation>,
 ) -> Result<(), kube::error::Error> {
@@ -375,7 +376,7 @@ async fn apply_redis(
 }
 
 async fn apply_jaeger(
-    cx: Arc<Context<impl IpfsRpcClient, impl RngCore>>,
+    cx: Arc<Context<impl IpfsRpcClient, impl RngCore, impl Clock>>,
     ns: &str,
     simulation: Arc<Simulation>,
 ) -> Result<(), kube::error::Error> {
@@ -405,7 +406,7 @@ async fn apply_jaeger(
 }
 
 async fn apply_prometheus(
-    cx: Arc<Context<impl IpfsRpcClient, impl RngCore>>,
+    cx: Arc<Context<impl IpfsRpcClient, impl RngCore, impl Clock>>,
     ns: &str,
     simulation: Arc<Simulation>,
 ) -> Result<(), kube::error::Error> {
@@ -434,7 +435,7 @@ async fn apply_prometheus(
 }
 
 async fn apply_opentelemetry(
-    cx: Arc<Context<impl IpfsRpcClient, impl RngCore>>,
+    cx: Arc<Context<impl IpfsRpcClient, impl RngCore, impl Clock>>,
     ns: &str,
     simulation: Arc<Simulation>,
 ) -> Result<(), kube::error::Error> {


### PR DESCRIPTION
Now that we are programmatically creating networks (see ceramic-tests) we want to make sure we are not leaving lots of unused resources around.

With this feature the test driver can create networks with a generous TTL of a few hours (when we expect tests to run in a few minutes). If for some reason the test driver fails to clean up the network itself, eventually the operator will clean it up.

This feature remains optional so manually created networks are not affected.