### PR TITLE
feat: run cas migrations in init container

### DIFF
--- a/operator/src/network/cas.rs
+++ b/operator/src/network/cas.rs
@@ -300,6 +300,28 @@ pub fn cas_stateful_set_spec(
                         ..Default::default()
                     },
                     Container {
+                        env: Some(
+                            [
+                                pg_env.clone(),
+                                vec![EnvVar {
+                                    name: "NODE_ENV".to_owned(),
+                                    value: Some("dev".to_owned()),
+                                    ..Default::default()
+                                }],
+                            ]
+                            .concat(),
+                        ),
+                        command: Some(
+                            ["./node_modules/knex/bin/cli.js", "migrate:latest"]
+                                .map(String::from)
+                                .to_vec(),
+                        ),
+                        image: Some(config.image.clone()),
+                        image_pull_policy: Some(config.image_pull_policy.clone()),
+                        name: "cas-migrations".to_owned(),
+                        ..Default::default()
+                    },
+                    Container {
                         env: Some(aws_env.clone()),
                         command: Some(
                             [

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -2242,6 +2242,17 @@ mod tests {
                              "name": "cas-worker",
                              "resources": {
                                "limits": {
+            @@ -442,8 +442,8 @@
+                                 "value": "dev"
+                               }
+                             ],
+            -                "image": "ceramicnetwork/ceramic-anchor-service:latest",
+            -                "imagePullPolicy": "Always",
+            +                "image": "cas/cas:dev",
+            +                "imagePullPolicy": "Never",
+                             "name": "cas-migrations"
+                           },
+                           {
         "#]]);
         let (testctx, api_handle) = Context::test(mock_rpc_client);
         let fakeserver = ApiServerVerifier::new(api_handle);

--- a/operator/src/network/testdata/default_stubs/cas_stateful_set
+++ b/operator/src/network/testdata/default_stubs/cas_stateful_set
@@ -407,6 +407,47 @@ Request {
               },
               {
                 "command": [
+                  "./node_modules/knex/bin/cli.js",
+                  "migrate:latest"
+                ],
+                "env": [
+                  {
+                    "name": "DB_NAME",
+                    "value": "anchor_db"
+                  },
+                  {
+                    "name": "DB_HOST",
+                    "value": "cas-postgres"
+                  },
+                  {
+                    "name": "DB_USERNAME",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "username",
+                        "name": "postgres-auth"
+                      }
+                    }
+                  },
+                  {
+                    "name": "DB_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "key": "password",
+                        "name": "postgres-auth"
+                      }
+                    }
+                  },
+                  {
+                    "name": "NODE_ENV",
+                    "value": "dev"
+                  }
+                ],
+                "image": "ceramicnetwork/ceramic-anchor-service:latest",
+                "imagePullPolicy": "Always",
+                "name": "cas-migrations"
+              },
+              {
+                "command": [
                   "aws",
                   "s3api",
                   "create-bucket",


### PR DESCRIPTION
This PR adds an init container to run knex migrations before CAS services start.

Occasionally, the CAS API and worker will get stuck on the migrations table, which gets locked. Better to run the migrations ahead of time so that neither service needs to run them during startup.