### PR TITLE
fix: update Dockerfile to use correct upstream parent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,15 @@ RUN --mount=type=cache,target=/home/builder/.cargo,uid=1001,gid=1001 \
     make build && \
     cp ./target/release/keramik-runner ./target/release/keramik-operator ./
 
-FROM ubuntu:latest as runner
+# This image needs to be the same as the parent image of rust-builder
+FROM debian:bookworm-slim as runner
 
 COPY --from=builder /home/builder/keramik/keramik-runner /usr/bin
 
 ENTRYPOINT ["/usr/bin/keramik-runner"]
 
-FROM ubuntu:latest as operator
+# This image needs to be the same as the parent image of rust-builder
+FROM debian:bookworm-slim as operator
 
 COPY --from=builder /home/builder/keramik/keramik-operator /usr/bin
 


### PR DESCRIPTION
Rust-builder no longer publishes the debian-latest tag and uses the debian flavor for its latest. This updates our Dockerfile to use the correct upstream parent image so we do not get glibc version conflicts.