### PR TITLE
feat: add env overrides to rust ipfs spec

### DIFF
--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -765,8 +765,8 @@ async fn reset_bootstrap_job(
 // Stub tests relying on stub.rs and its apiserver stubs
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
     use std::{collections::BTreeMap, time::Duration};
+    use std::{collections::HashMap, sync::Arc};
 
     use super::{reconcile, Network};
 
@@ -1780,12 +1780,12 @@ mod tests {
                            {
             -                "env": [
             -                  {
-            -                    "name": "RUST_LOG",
-            -                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-            -                  },
-            -                  {
             -                    "name": "CERAMIC_ONE_BIND_ADDRESS",
             -                    "value": "0.0.0.0:5001"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+            -                    "value": "0"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_METRICS",
@@ -1796,20 +1796,20 @@ mod tests {
             -                    "value": "0.0.0.0:9090"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-            -                    "value": "/ip4/0.0.0.0/tcp/4001"
+            -                    "name": "CERAMIC_ONE_NETWORK",
+            -                    "value": "local"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_STORE_DIR",
             -                    "value": "/data/ipfs"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_NETWORK",
-            -                    "value": "local"
+            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+            -                    "value": "/ip4/0.0.0.0/tcp/4001"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-            -                    "value": "0"
+            -                    "name": "RUST_LOG",
+            -                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
             -                  }
             -                ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -1905,12 +1905,12 @@ mod tests {
                            {
             -                "env": [
             -                  {
-            -                    "name": "RUST_LOG",
-            -                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-            -                  },
-            -                  {
             -                    "name": "CERAMIC_ONE_BIND_ADDRESS",
             -                    "value": "0.0.0.0:5001"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+            -                    "value": "0"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_METRICS",
@@ -1921,20 +1921,20 @@ mod tests {
             -                    "value": "0.0.0.0:9090"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-            -                    "value": "/ip4/0.0.0.0/tcp/4001"
+            -                    "name": "CERAMIC_ONE_NETWORK",
+            -                    "value": "local"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_STORE_DIR",
             -                    "value": "/data/ipfs"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_NETWORK",
-            -                    "value": "local"
+            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+            -                    "value": "/ip4/0.0.0.0/tcp/4001"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-            -                    "value": "0"
+            -                    "name": "RUST_LOG",
+            -                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
             -                  }
             -                ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -2049,12 +2049,12 @@ mod tests {
                            {
             -                "env": [
             -                  {
-            -                    "name": "RUST_LOG",
-            -                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-            -                  },
-            -                  {
             -                    "name": "CERAMIC_ONE_BIND_ADDRESS",
             -                    "value": "0.0.0.0:5001"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+            -                    "value": "0"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_METRICS",
@@ -2065,20 +2065,20 @@ mod tests {
             -                    "value": "0.0.0.0:9090"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-            -                    "value": "/ip4/0.0.0.0/tcp/4001"
+            -                    "name": "CERAMIC_ONE_NETWORK",
+            -                    "value": "local"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_STORE_DIR",
             -                    "value": "/data/ipfs"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_NETWORK",
-            -                    "value": "local"
+            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+            -                    "value": "/ip4/0.0.0.0/tcp/4001"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-            -                    "value": "0"
+            -                    "name": "RUST_LOG",
+            -                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
             -                  }
             -                ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -2141,6 +2141,12 @@ mod tests {
                             memory: Some(Quantity("4Gi".to_owned())),
                             storage: Some(Quantity("4Gi".to_owned())),
                         }),
+                        env: Some(HashMap::from_iter([
+                            ("ENV_KEY_A".to_string(), "ENV_VALUE_A".to_string()),
+                            ("ENV_KEY_B".to_string(), "ENV_VALUE_B".to_string()),
+                            // Override one existing var
+                            ("CERAMIC_ONE_METRICS".to_string(), "false".to_string()),
+                        ])),
                         ..Default::default()
                     })),
                     ..Default::default()
@@ -2170,8 +2176,29 @@ mod tests {
         stub.ceramics[0].stateful_set.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -171,7 +171,7 @@
-                                 "value": "0"
+            @@ -148,7 +148,7 @@
+                               },
+                               {
+                                 "name": "CERAMIC_ONE_METRICS",
+            -                    "value": "true"
+            +                    "value": "false"
+                               },
+                               {
+                                 "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
+            @@ -167,11 +167,19 @@
+                                 "value": "/ip4/0.0.0.0/tcp/4001"
+                               },
+                               {
+            +                    "name": "ENV_KEY_A",
+            +                    "value": "ENV_VALUE_A"
+            +                  },
+            +                  {
+            +                    "name": "ENV_KEY_B",
+            +                    "value": "ENV_VALUE_B"
+            +                  },
+            +                  {
+                                 "name": "RUST_LOG",
+                                 "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                                }
                              ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -2179,7 +2206,7 @@ mod tests {
                              "imagePullPolicy": "Always",
                              "name": "ipfs",
                              "ports": [
-            @@ -193,14 +193,14 @@
+            @@ -193,14 +201,14 @@
                              ],
                              "resources": {
                                "limits": {

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -1,4 +1,5 @@
 //! Place all spec types into a single module so they can be used as a lightweight dependency
+use std::collections::HashMap;
 
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use keramik_common::peer_info::Peer;
@@ -119,6 +120,9 @@ pub struct RustIpfsSpec {
     pub resource_limits: Option<ResourceLimitsSpec>,
     /// Value of the RUST_LOG env var.
     pub rust_log: Option<String>,
+    /// Extra env values to pass to the image.
+    /// CAUTION: Any env vars specified in this set will override any predefined values.
+    pub env: Option<HashMap<String, String>>,
 }
 
 /// Describes how the Go IPFS node for a peer should behave.

--- a/operator/src/network/testdata/ceramic_ss_1
+++ b/operator/src/network/testdata/ceramic_ss_1
@@ -139,12 +139,12 @@ Request {
               {
                 "env": [
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-                  },
-                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS",
@@ -155,20 +155,20 @@ Request {
                     "value": "0.0.0.0:9090"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_0
+++ b/operator/src/network/testdata/ceramic_ss_weighted_0
@@ -139,12 +139,12 @@ Request {
               {
                 "env": [
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-                  },
-                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS",
@@ -155,20 +155,20 @@ Request {
                     "value": "0.0.0.0:9090"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_1
+++ b/operator/src/network/testdata/ceramic_ss_weighted_1
@@ -139,12 +139,12 @@ Request {
               {
                 "env": [
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-                  },
-                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS",
@@ -155,20 +155,20 @@ Request {
                     "value": "0.0.0.0:9090"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_2
+++ b/operator/src/network/testdata/ceramic_ss_weighted_2
@@ -139,12 +139,12 @@ Request {
               {
                 "env": [
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-                  },
-                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS",
@@ -155,20 +155,20 @@ Request {
                     "value": "0.0.0.0:9090"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_3
+++ b/operator/src/network/testdata/ceramic_ss_weighted_3
@@ -139,12 +139,12 @@ Request {
               {
                 "env": [
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-                  },
-                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS",
@@ -155,20 +155,20 @@ Request {
                     "value": "0.0.0.0:9090"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_4
+++ b/operator/src/network/testdata/ceramic_ss_weighted_4
@@ -139,12 +139,12 @@ Request {
               {
                 "env": [
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-                  },
-                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS",
@@ -155,20 +155,20 @@ Request {
                     "value": "0.0.0.0:9090"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_5
+++ b/operator/src/network/testdata/ceramic_ss_weighted_5
@@ -139,12 +139,12 @@ Request {
               {
                 "env": [
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-                  },
-                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS",
@@ -155,20 +155,20 @@ Request {
                     "value": "0.0.0.0:9090"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_6
+++ b/operator/src/network/testdata/ceramic_ss_weighted_6
@@ -139,12 +139,12 @@ Request {
               {
                 "env": [
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-                  },
-                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS",
@@ -155,20 +155,20 @@ Request {
                     "value": "0.0.0.0:9090"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_7
+++ b/operator/src/network/testdata/ceramic_ss_weighted_7
@@ -139,12 +139,12 @@ Request {
               {
                 "env": [
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-                  },
-                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS",
@@ -155,20 +155,20 @@ Request {
                     "value": "0.0.0.0:9090"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_8
+++ b/operator/src/network/testdata/ceramic_ss_weighted_8
@@ -139,12 +139,12 @@ Request {
               {
                 "env": [
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-                  },
-                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS",
@@ -155,20 +155,20 @@ Request {
                     "value": "0.0.0.0:9090"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_9
+++ b/operator/src/network/testdata/ceramic_ss_weighted_9
@@ -139,12 +139,12 @@ Request {
               {
                 "env": [
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-                  },
-                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS",
@@ -155,20 +155,20 @@ Request {
                     "value": "0.0.0.0:9090"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/default_stubs/ceramic_stateful_set
+++ b/operator/src/network/testdata/default_stubs/ceramic_stateful_set
@@ -139,12 +139,12 @@ Request {
               {
                 "env": [
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
-                  },
-                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS",
@@ -155,20 +155,20 @@ Request {
                     "value": "0.0.0.0:9090"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,tracing_actix_web=debug"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",


### PR DESCRIPTION
This change allows us to play with all of the `ceramic-one` config via the network spec. 