### PR TITLE
fix: pin localstack image that doesn't try to delete its store

### DIFF
--- a/operator/src/network/cas.rs
+++ b/operator/src/network/cas.rs
@@ -863,7 +863,7 @@ pub fn localstack_stateful_set_spec(config: impl Into<CasConfig>) -> StatefulSet
             }),
             spec: Some(PodSpec {
                 containers: vec![Container {
-                    image: Some("localstack/localstack".to_owned()),
+                    image: Some("localstack/localstack@sha256:539f4145f9b3610d11b292457e657b7fd6ad0f7c93e206620056424faacf68b5".to_owned()),
                     image_pull_policy: Some("IfNotPresent".to_owned()),
                     name: "localstack".to_owned(),
                     ports: Some(vec![ContainerPort {

--- a/operator/src/network/testdata/default_stubs/localstack_stateful_set
+++ b/operator/src/network/testdata/default_stubs/localstack_stateful_set
@@ -32,7 +32,7 @@ Request {
           "spec": {
             "containers": [
               {
-                "image": "localstack/localstack",
+                "image": "localstack/localstack@sha256:539f4145f9b3610d11b292457e657b7fd6ad0f7c93e206620056424faacf68b5",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "localstack",
                 "ports": [


### PR DESCRIPTION
Newer images are trying to delete the store and crashing because k8s won't allow that. I'd rather not muck with localstack settings to figure this out.