### PR TITLE
fix: move persistant path for localstack to /var/lib

### DIFF
--- a/operator/src/network/cas.rs
+++ b/operator/src/network/cas.rs
@@ -876,7 +876,7 @@ pub fn localstack_stateful_set_spec(config: impl Into<CasConfig>) -> StatefulSet
                         ..Default::default()
                     }),
                     volume_mounts: Some(vec![VolumeMount {
-                        mount_path: "/tmp/localstack".to_owned(),
+                        mount_path: "/var/lib/localstack".to_owned(),
                         name: "localstack-data".to_owned(),
                         ..Default::default()
                     }]),

--- a/operator/src/network/testdata/default_stubs/localstack_stateful_set
+++ b/operator/src/network/testdata/default_stubs/localstack_stateful_set
@@ -54,7 +54,7 @@ Request {
                 },
                 "volumeMounts": [
                   {
-                    "mountPath": "/tmp/localstack",
+                    "mountPath": "/var/lib/localstack",
                     "name": "localstack-data"
                   }
                 ]


### PR DESCRIPTION
Built and pushed, seems to be working. There is data in the mapped path even with the pinned image version.