### PR TITLE
feat: add enabled flag to bootstrap spec

### DIFF
--- a/keramik/src/SUMMARY.md
+++ b/keramik/src/SUMMARY.md
@@ -17,3 +17,4 @@
   - [Secrets](./secrets.md)
   - [Operator Design](./operator.md)
   - [Migration Tests](./migration.md)
+  - [Custom Bootstrap Configuration](./advanced_bootstrap.md)

--- a/keramik/src/advanced.md
+++ b/keramik/src/advanced.md
@@ -5,3 +5,4 @@ For more advanced usage of keramik, please see
  - [Metrics](./metrics.md)
  - [IPFS](./ipfs.md)
  - [Secrets](./secrets.md)
+ - [Custom Bootstrap Configuration](./advanced_bootstrap.md)

--- a/keramik/src/advanced_bootstrap.md
+++ b/keramik/src/advanced_bootstrap.md
@@ -1,0 +1,20 @@
+# Advanced Bootstrap Configuration
+
+## Disable Bootstrap
+
+By default, Keramik will connect all IPFS peers to each other.
+This can be disabled using specific bootstrap configuration:
+
+
+```yaml
+# network configuration
+---
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: small
+spec:
+  replicas: 2
+  bootstrap:
+    enabled: false
+```

--- a/operator/src/network/bootstrap.rs
+++ b/operator/src/network/bootstrap.rs
@@ -9,6 +9,7 @@ use crate::network::{BootstrapSpec, PEERS_CONFIG_MAP_NAME};
 
 // BootstrapConfig defines which properties of the JobSpec can be customized.
 pub struct BootstrapConfig {
+    pub enabled: bool,
     pub image: String,
     pub image_pull_policy: String,
     pub method: String,
@@ -19,6 +20,7 @@ pub struct BootstrapConfig {
 impl Default for BootstrapConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             image: "public.ecr.aws/r5b3e0r5/3box/keramik-runner".to_owned(),
             image_pull_policy: "Always".to_owned(),
             method: "sentinel".to_owned(),
@@ -40,6 +42,7 @@ impl From<BootstrapSpec> for BootstrapConfig {
     fn from(value: BootstrapSpec) -> Self {
         let default = Self::default();
         Self {
+            enabled: value.enabled.unwrap_or(default.enabled),
             image: value.image.unwrap_or(default.image),
             image_pull_policy: value.image_pull_policy.unwrap_or(default.image_pull_policy),
             method: value.method.unwrap_or(default.method),
@@ -48,8 +51,8 @@ impl From<BootstrapSpec> for BootstrapConfig {
     }
 }
 
-pub fn bootstrap_job_spec(config: impl Into<BootstrapConfig>) -> JobSpec {
-    let config = config.into();
+pub fn bootstrap_job_spec(config: BootstrapConfig) -> JobSpec {
+    debug_assert!(config.enabled);
     JobSpec {
         backoff_limit: Some(4),
         template: PodTemplateSpec {

--- a/operator/src/network/ceramic.rs
+++ b/operator/src/network/ceramic.rs
@@ -358,12 +358,16 @@ impl Default for CeramicConfig {
 
 pub struct CeramicConfigs(pub Vec<CeramicConfig>);
 
-impl From<Vec<CeramicSpec>> for CeramicConfigs {
-    fn from(value: Vec<CeramicSpec>) -> Self {
-        if value.is_empty() {
-            Self(vec![CeramicConfig::default()])
+impl From<Option<Vec<CeramicSpec>>> for CeramicConfigs {
+    fn from(value: Option<Vec<CeramicSpec>>) -> Self {
+        if let Some(value) = value {
+            if value.is_empty() {
+                Self(vec![CeramicConfig::default()])
+            } else {
+                Self(value.into_iter().map(CeramicConfig::from).collect())
+            }
         } else {
-            Self(value.into_iter().map(CeramicConfig::from).collect())
+            Self(vec![CeramicConfig::default()])
         }
     }
 }

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -28,7 +28,7 @@ pub struct NetworkSpec {
     /// Total replicas will be split across each ceramic spec according to relative weights.
     /// It is possible that if the weight is small enough compared to others that a single spec
     /// will be assigned zero replicas.
-    pub ceramic: Vec<CeramicSpec>,
+    pub ceramic: Option<Vec<CeramicSpec>>,
     /// Name of secret containing the private key used for signing anchor requests and generating
     /// the Admin DID.
     pub private_key_secret: Option<String>,

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -67,9 +67,11 @@ pub struct NetworkStatus {
 }
 
 /// BootstrapSpec defines how the network bootstrap process should proceed.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BootstrapSpec {
+    /// When true bootstrap job will run, defaults to true.
+    pub enabled: Option<bool>,
     /// Image of the runner for the bootstrap job.
     pub image: Option<String>,
     /// Image pull policy for the bootstrap job.


### PR DESCRIPTION
Now its possible to simply disable the bootstrap process.

Additionally a small refactor was added to make the ceramic spec optional. Apparently k8s doesn't consider a vector optional and it must be explicit. 