### PR TITLE
fix: fixes bug where nodes were connecting to clay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,7 +2640,6 @@ dependencies = [
  "goose",
  "keramik-common",
  "libipld 0.16.0",
- "multibase 0.9.1",
  "multihash 0.17.0",
  "opentelemetry",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,6 +2640,7 @@ dependencies = [
  "goose",
  "keramik-common",
  "libipld 0.16.0",
+ "multibase 0.9.1",
  "multihash 0.17.0",
  "opentelemetry",
  "rand 0.8.5",

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ check-fmt:
 .PHONY: check-clippy
 check-clippy:
 	# Check with default features
-	${CARGO} clippy --workspace --all-targets
+	${CARGO} clippy --workspace
 	# Check with all features
-	${CARGO} clippy --workspace --all-targets --all-features
+	${CARGO} clippy --workspace --all-features
 
 .PHONY: build
 build: runner operator

--- a/k8s/operator/manifests/operator.yaml
+++ b/k8s/operator/manifests/operator.yaml
@@ -102,7 +102,7 @@ spec:
       containers:
       - name: keramik-operator
         image: "keramik/operator"
-        imagePullPolicy: IfNotPresent # Should be IfNotPresent when using imageTag: dev, but Always if using imageTag: latest
+        imagePullPolicy: Always # Should be IfNotPresent when using imageTag: dev, but Always if using imageTag: latest
         command:
           - "/usr/bin/keramik-operator"
           - "daemon"

--- a/keramik/src/advanced_configuration.md
+++ b/keramik/src/advanced_configuration.md
@@ -7,17 +7,15 @@ You can configure the Ceramic nodes to use an external instance of the CAS inste
 CAS running in 3Box Labs infrastructure, you will also need to specify the Ceramic network type associated with the
 node, e.g. `dev-unstable`.
 
-In this case, the Ceramic network PubSub topic must be specified as an empty string in order to clear it from the
-Ceramic configuration. Ceramic nodes do not permit the PubSub topic to be specified for a network type that is not one
-of `local` or `inmemory`.
-
 You may also specify an Ethereum RPC endpoint for the Ceramic nodes to be able to verify anchors, or set it to an empty
 string to clear it from the Ceramic configuration. In the latter case, the Ceramic nodes will come up but will not be
 able to verify anchors.
 
-If left unspecified, `networkType` will default to `local`, `pubsubTopic` to `/ceramic/local-keramik`, `ethRpcUrl` to
-`http://ganache:8545`, and `casApiUrl` to `http://cas:8081`. These defaults point to an internal CAS using a local
+If left unspecified, `networkType` will default to `local`, `ethRpcUrl` to `http://ganache:8545`,
+and `casApiUrl` to `http://cas:8081`. These defaults point to an internal CAS using a local
 pubsub topic in a fully isolated network.
+
+Additionally IPFS can be [configured](./ipfs.md) with custom images and resources for both CAS and Ceramic.
 
 ```yaml
 # network configuration
@@ -30,12 +28,12 @@ spec:
   replicas: 2
   privateKeySecret: "small"
   networkType: "dev-unstable"
-  pubsubTopic: ""
   ethRpcUrl: ""
   casApiUrl: "https://some-anchor-service.com"
 ```
 
 # Adjusting Ceramic Environment
+
 Ceramic environment can be adjusted by specifying environment variables in the network configuration
 
 ```yaml
@@ -53,6 +51,7 @@ spec:
 ```
 
 # Disabling AWS Functionality
+
 Certain functionality in CAS depends on AWS services. If you are running Keramik in a non-AWS environment, you can
 disable this by editing the statefulset for CAS
 
@@ -70,6 +69,7 @@ and adding the following environment variables to the `spec/template/spec/contai
 *Note* statefulsets must be edited every time the network is recreated.
 
 # Image Resources
+
 You can also use the [network](./setup_network.md) specification to specify resources for the pods that are running
 
 ```yaml

--- a/keramik/src/ipfs.md
+++ b/keramik/src/ipfs.md
@@ -1,10 +1,12 @@
 # IPFS
 
-The IPFS behavior used by Ceramic can be customized.
+The IPFS behavior used by CAS and Ceramic can be customized using the same IPFS spec.
 
 ## Rust IPFS
 
-Example [network config](./setup_network.md) that uses Rust based IPFS (i.e. ceramic-one) with its defaults.
+### Ceramic
+
+Example [network config](./setup_network.md) that uses Rust based IPFS (i.e. ceramic-one) with its defaults for Ceramic.
 
 ```yaml
 apiVersion: "keramik.3box.io/v1alpha1"
@@ -18,7 +20,7 @@ spec:
         rust: {}
 ```
 
-Example [network config](./setup_network.md) that uses Rust based IPFS (i.e. ceramic-one) with a specific image.
+Example [network config](./setup_network.md) that uses Rust based IPFS (i.e. ceramic-one) with a specific image for Ceramic.
 
 ```yaml
 apiVersion: "keramik.3box.io/v1alpha1"
@@ -34,9 +36,43 @@ spec:
          imagePullPolicy: IfNotPresent
 ```
 
+### CAS
+
+Example [network config](./setup_network.md) that uses Rust based IPFS (i.e. ceramic-one) with a specific image for CAS.
+
+```yaml
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: example-vanilla-ceramic-one
+spec:
+  replicas: 5
+  cas:
+    ipfs:
+      rust: {}
+```
+
+Example [network config](./setup_network.md) that uses Rust based IPFS (i.e. ceramic-one) with a specific image for CAS.
+
+```yaml
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: example-custom-ceramic-one
+spec:
+  replicas: 5
+  cas:
+    ipfs:
+     rust:
+       image: rust-ceramic/ceramic-one:dev
+       imagePullPolicy: IfNotPresent
+```
+
 ## Kubo IPFS
 
-Example [network config](./setup_network.md) that uses Go based IPFS (i.e. Kubo) with its defaults.
+### Ceramic
+
+Example [network config](./setup_network.md) that uses Go based IPFS (i.e. Kubo) with its defaults for Ceramic.
 
 ```yaml
 apiVersion: "keramik.3box.io/v1alpha1"
@@ -50,7 +86,7 @@ spec:
         go: {}
 ```
 
-Example [network config](./setup_network.md) that uses Go based IPFS (i.e. Kubo) with a specific image.
+Example [network config](./setup_network.md) that uses Go based IPFS (i.e. Kubo) with a specific image for Ceramic.
 
 ```yaml
 apiVersion: "keramik.3box.io/v1alpha1"
@@ -66,7 +102,7 @@ spec:
          imagePullPolicy: IfNotPresent
 ```
 
-Example [network config](./setup_network.md) that uses Go based IPFS (i.e. Kubo) with extra configuration commands.
+Example [network config](./setup_network.md) that uses Go based IPFS (i.e. Kubo) with extra configuration commands for Ceramic.
 
 ```yaml
 apiVersion: "keramik.3box.io/v1alpha1"
@@ -82,4 +118,54 @@ spec:
          imagePullPolicy: IfNotPresent
          commands:
            - ipfs config --json Swarm.RelayClient.Enabled false
+```
+
+### CAS
+
+Example [network config](./setup_network.md) that uses Go based IPFS (i.e. Kubo) with its defaults for CAS.
+
+```yaml
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: example-vanilla-kubo
+spec:
+  replicas: 5
+  cas:
+    ipfs:
+      go: {}
+```
+
+Example [network config](./setup_network.md) that uses Go based IPFS (i.e. Kubo) with a specific image for CAS.
+
+```yaml
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: example-custom-kubo
+spec:
+  replicas: 5
+  cas:
+    ipfs:
+     go:
+       image: ceramicnetwork/go-ipfs-daemon:develop
+       imagePullPolicy: IfNotPresent
+```
+
+Example [network config](./setup_network.md) that uses Go based IPFS (i.e. Kubo) with extra configuration commands for CAS.
+
+```yaml
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: example-custom-kubo
+spec:
+  replicas: 5
+  cas:
+    ipfs:
+     go:
+       image: ceramicnetwork/go-ipfs-daemon:develop
+       imagePullPolicy: IfNotPresent
+       commands:
+         - ipfs config --json Swarm.RelayClient.Enabled false
 ```

--- a/operator/src/network/ceramic.rs
+++ b/operator/src/network/ceramic.rs
@@ -494,7 +494,7 @@ pub fn stateful_set_spec(ns: &str, bundle: &CeramicBundle<'_>) -> StatefulSetSpe
                     bundle
                         .config
                         .ipfs
-                        .container(&bundle.info, &bundle.net_config),
+                        .container(&bundle.info, bundle.net_config),
                 ],
                 init_containers: Some(vec![Container {
                     command: Some(vec![

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -1928,7 +1928,7 @@ mod tests {
         stub.ceramics[0].stateful_set.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -137,50 +137,8 @@
+            @@ -137,46 +137,8 @@
                              ]
                            },
                            {
@@ -1950,10 +1950,6 @@ mod tests {
             -                    "value": "0"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_METRICS",
-            -                    "value": "true"
-            -                  },
-            -                  {
             -                    "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
             -                    "value": "0.0.0.0:9465"
             -                  },
@@ -1971,7 +1967,7 @@ mod tests {
             -                  },
             -                  {
             -                    "name": "RUST_LOG",
-            -                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+            -                    "value": "info,ceramic_one=debug,multipart=error"
             -                  }
             -                ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -1981,7 +1977,7 @@ mod tests {
                              "name": "ipfs",
                              "ports": [
                                {
-            @@ -215,6 +173,11 @@
+            @@ -211,6 +173,11 @@
                                {
                                  "mountPath": "/data/ipfs",
                                  "name": "ipfs-data"
@@ -1993,7 +1989,7 @@ mod tests {
                                }
                              ]
                            }
-            @@ -323,6 +286,13 @@
+            @@ -319,6 +286,13 @@
                              "persistentVolumeClaim": {
                                "claimName": "ipfs-data"
                              }
@@ -2061,7 +2057,7 @@ mod tests {
         stub.ceramics[0].stateful_set.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -137,50 +137,8 @@
+            @@ -137,46 +137,8 @@
                              ]
                            },
                            {
@@ -2083,10 +2079,6 @@ mod tests {
             -                    "value": "0"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_METRICS",
-            -                    "value": "true"
-            -                  },
-            -                  {
             -                    "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
             -                    "value": "0.0.0.0:9465"
             -                  },
@@ -2104,7 +2096,7 @@ mod tests {
             -                  },
             -                  {
             -                    "name": "RUST_LOG",
-            -                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+            -                    "value": "info,ceramic_one=debug,multipart=error"
             -                  }
             -                ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -2114,7 +2106,7 @@ mod tests {
                              "name": "ipfs",
                              "ports": [
                                {
-            @@ -201,14 +159,14 @@
+            @@ -197,14 +159,14 @@
                              ],
                              "resources": {
                                "limits": {
@@ -2135,7 +2127,7 @@ mod tests {
                                }
                              },
                              "volumeMounts": [
-            @@ -215,6 +173,11 @@
+            @@ -211,6 +173,11 @@
                                {
                                  "mountPath": "/data/ipfs",
                                  "name": "ipfs-data"
@@ -2147,7 +2139,7 @@ mod tests {
                                }
                              ]
                            }
-            @@ -323,6 +286,13 @@
+            @@ -319,6 +286,13 @@
                              "persistentVolumeClaim": {
                                "claimName": "ipfs-data"
                              }
@@ -2213,7 +2205,7 @@ mod tests {
         stub.ceramics[0].stateful_set.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -137,50 +137,8 @@
+            @@ -137,46 +137,8 @@
                              ]
                            },
                            {
@@ -2235,10 +2227,6 @@ mod tests {
             -                    "value": "0"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_METRICS",
-            -                    "value": "true"
-            -                  },
-            -                  {
             -                    "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
             -                    "value": "0.0.0.0:9465"
             -                  },
@@ -2256,7 +2244,7 @@ mod tests {
             -                  },
             -                  {
             -                    "name": "RUST_LOG",
-            -                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+            -                    "value": "info,ceramic_one=debug,multipart=error"
             -                  }
             -                ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -2266,7 +2254,7 @@ mod tests {
                              "name": "ipfs",
                              "ports": [
                                {
-            @@ -215,6 +173,16 @@
+            @@ -211,6 +173,16 @@
                                {
                                  "mountPath": "/data/ipfs",
                                  "name": "ipfs-data"
@@ -2283,7 +2271,7 @@ mod tests {
                                }
                              ]
                            }
-            @@ -323,6 +291,13 @@
+            @@ -319,6 +291,13 @@
                              "persistentVolumeClaim": {
                                "claimName": "ipfs-data"
                              }
@@ -2354,16 +2342,18 @@ mod tests {
         stub.ceramics[0].stateful_set.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -156,7 +156,7 @@
+            @@ -155,6 +155,10 @@
+                                 "value": "0"
                                },
                                {
-                                 "name": "CERAMIC_ONE_METRICS",
-            -                    "value": "true"
+            +                    "name": "CERAMIC_ONE_METRICS",
             +                    "value": "false"
-                               },
-                               {
+            +                  },
+            +                  {
                                  "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
-            @@ -175,11 +175,19 @@
+                                 "value": "0.0.0.0:9465"
+                               },
+            @@ -171,11 +175,19 @@
                                  "value": "/ip4/0.0.0.0/tcp/4001"
                                },
                                {
@@ -2376,7 +2366,7 @@ mod tests {
             +                  },
             +                  {
                                  "name": "RUST_LOG",
-                                 "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                                 "value": "info,ceramic_one=debug,multipart=error"
                                }
                              ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -2384,7 +2374,7 @@ mod tests {
                              "imagePullPolicy": "Always",
                              "name": "ipfs",
                              "ports": [
-            @@ -201,14 +209,14 @@
+            @@ -197,14 +209,14 @@
                              ],
                              "resources": {
                                "limits": {
@@ -2502,11 +2492,14 @@ mod tests {
                         memory: Some(Quantity("1Gi".to_owned())),
                         storage: Some(Quantity("1Gi".to_owned())),
                     }),
-                    ipfs_resource_limits: Some(ResourceLimitsSpec {
-                        cpu: Some(Quantity("2".to_owned())),
-                        memory: Some(Quantity("2Gi".to_owned())),
-                        storage: Some(Quantity("2Gi".to_owned())),
-                    }),
+                    ipfs: Some(IpfsSpec::Rust(RustIpfsSpec {
+                        resource_limits: Some(ResourceLimitsSpec {
+                            cpu: Some(Quantity("2".to_owned())),
+                            memory: Some(Quantity("2Gi".to_owned())),
+                            storage: Some(Quantity("2Gi".to_owned())),
+                        }),
+                        ..Default::default()
+                    })),
                     ganache_resource_limits: Some(ResourceLimitsSpec {
                         cpu: Some(Quantity("3".to_owned())),
                         memory: Some(Quantity("3Gi".to_owned())),
@@ -2593,7 +2586,7 @@ mod tests {
         stub.cas_ipfs_stateful_set.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -77,14 +77,14 @@
+            @@ -92,14 +92,14 @@
                              ],
                              "resources": {
                                "limits": {
@@ -2732,7 +2725,7 @@ mod tests {
                                }
                              },
                              "volumeMounts": [
-            @@ -278,14 +278,14 @@
+            @@ -274,14 +274,14 @@
                              "name": "init-ceramic-config",
                              "resources": {
                                "limits": {
@@ -2914,8 +2907,8 @@ mod tests {
                                },
                                {
                                  "name": "CERAMIC_NETWORK_TOPIC",
-            -                    "value": "/ceramic/local-keramik"
-            +                    "value": ""
+            -                    "value": "/ceramic/local-0"
+            +                    "value": "/ceramic/dev-unstable"
                                },
                                {
                                  "name": "ETH_RPC_URL",
@@ -2929,7 +2922,16 @@ mod tests {
                                },
                                {
                                  "name": "CERAMIC_SQLITE_PATH",
-            @@ -238,19 +238,19 @@
+            @@ -160,7 +160,7 @@
+                               },
+                               {
+                                 "name": "CERAMIC_ONE_NETWORK",
+            -                    "value": "local"
+            +                    "value": "dev-unstable"
+                               },
+                               {
+                                 "name": "CERAMIC_ONE_STORE_DIR",
+            @@ -234,19 +234,19 @@
                                },
                                {
                                  "name": "CERAMIC_NETWORK",
@@ -2938,8 +2940,8 @@ mod tests {
                                },
                                {
                                  "name": "CERAMIC_NETWORK_TOPIC",
-            -                    "value": "/ceramic/local-keramik"
-            +                    "value": ""
+            -                    "value": "/ceramic/local-0"
+            +                    "value": "/ceramic/dev-unstable"
                                },
                                {
                                  "name": "ETH_RPC_URL",
@@ -2989,7 +2991,7 @@ mod tests {
                              "livenessProbe": {
                                "httpGet": {
                                  "path": "/api/v0/node/healthcheck",
-            @@ -273,8 +273,8 @@
+            @@ -269,8 +269,8 @@
                                  "value": "2"
                                }
                              ],
@@ -3334,7 +3336,7 @@ mod tests {
                                }
                              ],
                              "image": "ceramicnetwork/composedb:latest",
-            @@ -271,6 +275,10 @@
+            @@ -267,6 +271,10 @@
                                {
                                  "name": "CERAMIC_LOG_LEVEL",
                                  "value": "2"

--- a/operator/src/network/ipfs.rs
+++ b/operator/src/network/ipfs.rs
@@ -1,0 +1,364 @@
+use std::collections::BTreeMap;
+
+use k8s_openapi::{
+    api::core::v1::{
+        ConfigMapVolumeSource, Container, ContainerPort, EnvVar, ResourceRequirements, Volume,
+        VolumeMount,
+    },
+    apimachinery::pkg::api::resource::Quantity,
+};
+
+const IPFS_CONTAINER_NAME: &str = "ipfs";
+pub const IPFS_DATA_PV_CLAIM: &str = "ipfs-data";
+const IPFS_SERVICE_PORT: i32 = 5001;
+
+use crate::network::{
+    ceramic::NetworkConfig, resource_limits::ResourceLimitsConfig, GoIpfsSpec, IpfsSpec,
+    RustIpfsSpec, NETWORK_LOCAL_ID,
+};
+
+/// Unique identifying information about this IPFS spec.
+#[derive(Debug, Clone)]
+pub struct IpfsInfo {
+    suffix: String,
+}
+
+impl IpfsInfo {
+    pub fn new(suffix: String) -> Self {
+        Self { suffix }
+    }
+    /// Generate a new uninque name for this ceramic spec
+    /// Generated name is deterministic for a given input name.
+    pub fn new_name(&self, name: &str) -> String {
+        format!("{name}-{}", self.suffix)
+    }
+}
+
+pub enum IpfsConfig {
+    Rust(RustIpfsConfig),
+    Go(GoIpfsConfig),
+}
+impl From<IpfsSpec> for IpfsConfig {
+    fn from(value: IpfsSpec) -> Self {
+        match value {
+            IpfsSpec::Rust(spec) => Self::Rust(spec.into()),
+            IpfsSpec::Go(spec) => Self::Go(spec.into()),
+        }
+    }
+}
+
+impl Default for IpfsConfig {
+    fn default() -> Self {
+        Self::Rust(Default::default())
+    }
+}
+impl IpfsConfig {
+    pub fn config_maps(
+        &self,
+        info: impl Into<IpfsInfo>,
+    ) -> BTreeMap<String, BTreeMap<String, String>> {
+        let info = info.into();
+        match self {
+            IpfsConfig::Rust(_) => BTreeMap::new(),
+            IpfsConfig::Go(config) => config.config_maps(&info),
+        }
+    }
+    pub fn container(&self, info: impl Into<IpfsInfo>, net_config: &NetworkConfig) -> Container {
+        let info = info.into();
+        match self {
+            IpfsConfig::Rust(config) => config.container(net_config),
+            IpfsConfig::Go(config) => config.container(&info),
+        }
+    }
+    pub fn volumes(&self, info: impl Into<IpfsInfo>) -> Vec<Volume> {
+        let info = info.into();
+        match self {
+            IpfsConfig::Rust(_) => Vec::new(),
+            IpfsConfig::Go(config) => config.volumes(&info),
+        }
+    }
+}
+
+pub struct RustIpfsConfig {
+    image: String,
+    image_pull_policy: String,
+    resource_limits: ResourceLimitsConfig,
+    rust_log: String,
+    env: Option<BTreeMap<String, String>>,
+}
+impl Default for RustIpfsConfig {
+    fn default() -> Self {
+        Self {
+            image: "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest".to_owned(),
+            image_pull_policy: "Always".to_owned(),
+            resource_limits: ResourceLimitsConfig {
+                cpu: Quantity("250m".to_owned()),
+                memory: Quantity("512Mi".to_owned()),
+                storage: Quantity("1Gi".to_owned()),
+            },
+            rust_log: "info,ceramic_one=debug,multipart=error".to_owned(),
+            env: None,
+        }
+    }
+}
+impl From<RustIpfsSpec> for RustIpfsConfig {
+    fn from(value: RustIpfsSpec) -> Self {
+        let default = RustIpfsConfig::default();
+        Self {
+            image: value.image.unwrap_or(default.image),
+            image_pull_policy: value.image_pull_policy.unwrap_or(default.image_pull_policy),
+            resource_limits: ResourceLimitsConfig::from_spec(
+                value.resource_limits,
+                default.resource_limits,
+            ),
+            rust_log: value.rust_log.unwrap_or(default.rust_log),
+            env: value.env,
+        }
+    }
+}
+impl RustIpfsConfig {
+    fn container(&self, net_config: &NetworkConfig) -> Container {
+        let mut env = vec![
+            EnvVar {
+                name: "RUST_LOG".to_owned(),
+                value: Some(self.rust_log.to_owned()),
+                ..Default::default()
+            },
+            EnvVar {
+                name: "CERAMIC_ONE_BIND_ADDRESS".to_owned(),
+                value: Some(format!("0.0.0.0:{IPFS_SERVICE_PORT}")),
+                ..Default::default()
+            },
+            EnvVar {
+                name: "CERAMIC_ONE_METRICS_BIND_ADDRESS".to_owned(),
+                value: Some("0.0.0.0:9465".to_owned()),
+                ..Default::default()
+            },
+            EnvVar {
+                name: "CERAMIC_ONE_SWARM_ADDRESSES".to_owned(),
+                value: Some("/ip4/0.0.0.0/tcp/4001".to_owned()),
+                ..Default::default()
+            },
+            EnvVar {
+                name: "CERAMIC_ONE_STORE_DIR".to_owned(),
+                value: Some("/data/ipfs".to_owned()),
+                ..Default::default()
+            },
+            EnvVar {
+                name: "CERAMIC_ONE_NETWORK".to_owned(),
+                value: Some(net_config.network_type.name().to_owned()),
+                ..Default::default()
+            },
+            EnvVar {
+                name: "CERAMIC_ONE_LOCAL_NETWORK_ID".to_owned(),
+                value: Some(NETWORK_LOCAL_ID.to_string()),
+                ..Default::default()
+            },
+            EnvVar {
+                name: "CERAMIC_ONE_KADEMLIA_REPLICATION".to_owned(),
+                value: Some("6".to_owned()),
+                ..Default::default()
+            },
+            EnvVar {
+                name: "CERAMIC_ONE_KADEMLIA_PARALLELISM".to_owned(),
+                value: Some("1".to_owned()),
+                ..Default::default()
+            },
+        ];
+        if let Some(extra_env) = &self.env {
+            extra_env.iter().for_each(|(key, value)| {
+                if let Some((pos, _)) = env.iter().enumerate().find(|(_, var)| &var.name == key) {
+                    env.swap_remove(pos);
+                }
+                env.push(EnvVar {
+                    name: key.to_string(),
+                    value: Some(value.to_string()),
+                    ..Default::default()
+                })
+            });
+        }
+        // Sort env vars so we can have stable tests
+        env.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+        Container {
+            env: Some(env),
+            image: Some(self.image.to_owned()),
+            image_pull_policy: Some(self.image_pull_policy.to_owned()),
+            name: IPFS_CONTAINER_NAME.to_owned(),
+            ports: Some(vec![
+                ContainerPort {
+                    container_port: 4001,
+                    name: Some("swarm-tcp".to_owned()),
+                    protocol: Some("TCP".to_owned()),
+                    ..Default::default()
+                },
+                ContainerPort {
+                    container_port: IPFS_SERVICE_PORT,
+                    name: Some("rpc".to_owned()),
+                    protocol: Some("TCP".to_owned()),
+                    ..Default::default()
+                },
+                ContainerPort {
+                    container_port: 9465,
+                    name: Some("metrics".to_owned()),
+                    protocol: Some("TCP".to_owned()),
+                    ..Default::default()
+                },
+            ]),
+            resources: Some(ResourceRequirements {
+                limits: Some(self.resource_limits.clone().into()),
+                requests: Some(self.resource_limits.clone().into()),
+                ..Default::default()
+            }),
+            volume_mounts: Some(vec![VolumeMount {
+                mount_path: "/data/ipfs".to_owned(),
+                name: IPFS_DATA_PV_CLAIM.to_owned(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }
+    }
+}
+
+pub struct GoIpfsConfig {
+    image: String,
+    image_pull_policy: String,
+    resource_limits: ResourceLimitsConfig,
+    commands: Vec<String>,
+}
+impl Default for GoIpfsConfig {
+    fn default() -> Self {
+        Self {
+            image: "ipfs/kubo:v0.19.1@sha256:c4527752a2130f55090be89ade8dde8f8a5328ec72570676b90f66e2cabf827d".to_owned(),
+            image_pull_policy: "IfNotPresent".to_owned(),
+            resource_limits: ResourceLimitsConfig {
+                cpu: Quantity("250m".to_owned()),
+                memory: Quantity("512Mi".to_owned()),
+                storage: Quantity("1Gi".to_owned()),
+            },
+            commands: vec![],
+        }
+    }
+}
+impl From<GoIpfsSpec> for GoIpfsConfig {
+    fn from(value: GoIpfsSpec) -> Self {
+        let default = GoIpfsConfig::default();
+        Self {
+            image: value.image.unwrap_or(default.image),
+            image_pull_policy: value.image_pull_policy.unwrap_or(default.image_pull_policy),
+            resource_limits: ResourceLimitsConfig::from_spec(
+                value.resource_limits,
+                default.resource_limits,
+            ),
+            commands: value.commands.unwrap_or(default.commands),
+        }
+    }
+}
+impl GoIpfsConfig {
+    fn config_maps(&self, info: &IpfsInfo) -> BTreeMap<String, BTreeMap<String, String>> {
+        let mut ipfs_config = vec![(
+            "001-config.sh".to_owned(),
+            r#"#!/bin/sh
+set -ex
+# Do not bootstrap against public nodes
+ipfs bootstrap rm all
+# Do not sticky peer with ceramic specific peers
+# We want an isolated network
+ipfs config --json Peering.Peers '[]'
+# Disable the gateway
+ipfs config  --json Addresses.Gateway '[]'
+# Enable pubsub
+ipfs config  --json PubSub.Enabled true
+# Only listen on specific tcp address as nothing else is exposed
+ipfs config  --json Addresses.Swarm '["/ip4/0.0.0.0/tcp/4001"]'
+# Set explicit resource manager limits as Kubo computes them based off
+# the k8s node resources and not the pods limits.
+ipfs config Swarm.ResourceMgr.MaxMemory '400 MB'
+ipfs config --json Swarm.ResourceMgr.MaxFileDescriptors 500000
+"#
+            .to_owned(),
+        )];
+        if !self.commands.is_empty() {
+            ipfs_config.push((
+                "002-config.sh".to_owned(),
+                [
+                    vec!["#!/bin/sh", "set -ex"],
+                    self.commands.iter().map(AsRef::as_ref).collect(),
+                ]
+                .concat()
+                .join("\n"),
+            ));
+        }
+        BTreeMap::from_iter(vec![(
+            info.new_name("ipfs-container-init"),
+            BTreeMap::from_iter(ipfs_config),
+        )])
+    }
+    fn container(&self, info: &IpfsInfo) -> Container {
+        let mut volume_mounts = vec![
+            VolumeMount {
+                mount_path: "/data/ipfs".to_owned(),
+                name: IPFS_DATA_PV_CLAIM.to_owned(),
+                ..Default::default()
+            },
+            VolumeMount {
+                mount_path: "/container-init.d/001-config.sh".to_owned(),
+                name: info.new_name("ipfs-container-init"),
+                // Use an explict subpath otherwise, k8s uses symlinks which breaks
+                // kubo's init logic.
+                sub_path: Some("001-config.sh".to_owned()),
+                ..Default::default()
+            },
+        ];
+        if !self.commands.is_empty() {
+            volume_mounts.push(VolumeMount {
+                mount_path: "/container-init.d/002-config.sh".to_owned(),
+                name: info.new_name("ipfs-container-init"),
+                sub_path: Some("002-config.sh".to_owned()),
+                ..Default::default()
+            })
+        }
+        Container {
+            image: Some(self.image.to_owned()),
+            image_pull_policy: Some(self.image_pull_policy.to_owned()),
+            name: IPFS_CONTAINER_NAME.to_owned(),
+            ports: Some(vec![
+                ContainerPort {
+                    container_port: 4001,
+                    name: Some("swarm-tcp".to_owned()),
+                    protocol: Some("TCP".to_owned()),
+                    ..Default::default()
+                },
+                ContainerPort {
+                    container_port: IPFS_SERVICE_PORT,
+                    name: Some("rpc".to_owned()),
+                    protocol: Some("TCP".to_owned()),
+                    ..Default::default()
+                },
+                ContainerPort {
+                    container_port: 9465,
+                    name: Some("metrics".to_owned()),
+                    protocol: Some("TCP".to_owned()),
+                    ..Default::default()
+                },
+            ]),
+            resources: Some(ResourceRequirements {
+                limits: Some(self.resource_limits.clone().into()),
+                requests: Some(self.resource_limits.clone().into()),
+                ..Default::default()
+            }),
+            volume_mounts: Some(volume_mounts),
+            ..Default::default()
+        }
+    }
+    fn volumes(&self, info: &IpfsInfo) -> Vec<Volume> {
+        vec![Volume {
+            name: info.new_name("ipfs-container-init"),
+            config_map: Some(ConfigMapVolumeSource {
+                default_mode: Some(0o755),
+                name: Some(info.new_name("ipfs-container-init")),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }]
+    }
+}

--- a/operator/src/network/mod.rs
+++ b/operator/src/network/mod.rs
@@ -1,7 +1,6 @@
 //! Network is k8s custom resource that defines a Ceramic network.
 
 // Export all spec types
-mod ipfs;
 mod spec;
 pub use spec::*;
 
@@ -16,6 +15,8 @@ pub(crate) mod ceramic;
 pub(crate) mod controller;
 #[cfg(feature = "controller")]
 pub(crate) mod datadog;
+#[cfg(feature = "controller")]
+pub(crate) mod ipfs;
 #[cfg(feature = "controller")]
 pub(crate) mod ipfs_rpc;
 #[cfg(feature = "controller")]

--- a/operator/src/network/mod.rs
+++ b/operator/src/network/mod.rs
@@ -1,6 +1,7 @@
 //! Network is k8s custom resource that defines a Ceramic network.
 
 // Export all spec types
+mod ipfs;
 mod spec;
 pub use spec::*;
 

--- a/operator/src/network/testdata/ceramic_go_ss_1
+++ b/operator/src/network/testdata/ceramic_go_ss_1
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -205,7 +205,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/network/testdata/ceramic_ss_1
+++ b/operator/src/network/testdata/ceramic_ss_1
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -155,10 +155,6 @@ Request {
                     "value": "0"
                   },
                   {
-                    "name": "CERAMIC_ONE_METRICS",
-                    "value": "true"
-                  },
-                  {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
@@ -176,7 +172,7 @@ Request {
                   },
                   {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -242,7 +238,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/network/testdata/ceramic_ss_weighted_0
+++ b/operator/src/network/testdata/ceramic_ss_weighted_0
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -155,10 +155,6 @@ Request {
                     "value": "0"
                   },
                   {
-                    "name": "CERAMIC_ONE_METRICS",
-                    "value": "true"
-                  },
-                  {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
@@ -176,7 +172,7 @@ Request {
                   },
                   {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -242,7 +238,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/network/testdata/ceramic_ss_weighted_1
+++ b/operator/src/network/testdata/ceramic_ss_weighted_1
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -155,10 +155,6 @@ Request {
                     "value": "0"
                   },
                   {
-                    "name": "CERAMIC_ONE_METRICS",
-                    "value": "true"
-                  },
-                  {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
@@ -176,7 +172,7 @@ Request {
                   },
                   {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -242,7 +238,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/network/testdata/ceramic_ss_weighted_2
+++ b/operator/src/network/testdata/ceramic_ss_weighted_2
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -155,10 +155,6 @@ Request {
                     "value": "0"
                   },
                   {
-                    "name": "CERAMIC_ONE_METRICS",
-                    "value": "true"
-                  },
-                  {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
@@ -176,7 +172,7 @@ Request {
                   },
                   {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -242,7 +238,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/network/testdata/ceramic_ss_weighted_3
+++ b/operator/src/network/testdata/ceramic_ss_weighted_3
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -155,10 +155,6 @@ Request {
                     "value": "0"
                   },
                   {
-                    "name": "CERAMIC_ONE_METRICS",
-                    "value": "true"
-                  },
-                  {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
@@ -176,7 +172,7 @@ Request {
                   },
                   {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -242,7 +238,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/network/testdata/ceramic_ss_weighted_4
+++ b/operator/src/network/testdata/ceramic_ss_weighted_4
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -155,10 +155,6 @@ Request {
                     "value": "0"
                   },
                   {
-                    "name": "CERAMIC_ONE_METRICS",
-                    "value": "true"
-                  },
-                  {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
@@ -176,7 +172,7 @@ Request {
                   },
                   {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -242,7 +238,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/network/testdata/ceramic_ss_weighted_5
+++ b/operator/src/network/testdata/ceramic_ss_weighted_5
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -155,10 +155,6 @@ Request {
                     "value": "0"
                   },
                   {
-                    "name": "CERAMIC_ONE_METRICS",
-                    "value": "true"
-                  },
-                  {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
@@ -176,7 +172,7 @@ Request {
                   },
                   {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -242,7 +238,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/network/testdata/ceramic_ss_weighted_6
+++ b/operator/src/network/testdata/ceramic_ss_weighted_6
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -155,10 +155,6 @@ Request {
                     "value": "0"
                   },
                   {
-                    "name": "CERAMIC_ONE_METRICS",
-                    "value": "true"
-                  },
-                  {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
@@ -176,7 +172,7 @@ Request {
                   },
                   {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -242,7 +238,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/network/testdata/ceramic_ss_weighted_7
+++ b/operator/src/network/testdata/ceramic_ss_weighted_7
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -155,10 +155,6 @@ Request {
                     "value": "0"
                   },
                   {
-                    "name": "CERAMIC_ONE_METRICS",
-                    "value": "true"
-                  },
-                  {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
@@ -176,7 +172,7 @@ Request {
                   },
                   {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -242,7 +238,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/network/testdata/ceramic_ss_weighted_8
+++ b/operator/src/network/testdata/ceramic_ss_weighted_8
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -155,10 +155,6 @@ Request {
                     "value": "0"
                   },
                   {
-                    "name": "CERAMIC_ONE_METRICS",
-                    "value": "true"
-                  },
-                  {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
@@ -176,7 +172,7 @@ Request {
                   },
                   {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -242,7 +238,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/network/testdata/ceramic_ss_weighted_9
+++ b/operator/src/network/testdata/ceramic_ss_weighted_9
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -155,10 +155,6 @@ Request {
                     "value": "0"
                   },
                   {
-                    "name": "CERAMIC_ONE_METRICS",
-                    "value": "true"
-                  },
-                  {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
@@ -176,7 +172,7 @@ Request {
                   },
                   {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -242,7 +238,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/network/testdata/default_stubs/cas_ipfs_stateful_set
+++ b/operator/src/network/testdata/default_stubs/cas_ipfs_stateful_set
@@ -32,47 +32,62 @@ Request {
           "spec": {
             "containers": [
               {
-                "command": [
-                  "/usr/bin/ceramic-one",
-                  "daemon",
-                  "--store-dir",
-                  "/data/ipfs",
-                  "-b",
-                  "0.0.0.0:5001"
-                ],
                 "env": [
                   {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
+                    "name": "CERAMIC_ONE_BIND_ADDRESS",
+                    "value": "0.0.0.0:5001"
                   },
                   {
                     "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
                     "value": "1"
                   },
                   {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
+                    "value": "0.0.0.0:9465"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_STORE_DIR",
+                    "value": "/data/ipfs"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
+                  },
+                  {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
-                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one",
+                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
                 "imagePullPolicy": "Always",
                 "name": "ipfs",
                 "ports": [
                   {
                     "containerPort": 4001,
-                    "name": "swarm-tcp"
+                    "name": "swarm-tcp",
+                    "protocol": "TCP"
                   },
                   {
                     "containerPort": 5001,
-                    "name": "api"
+                    "name": "rpc",
+                    "protocol": "TCP"
                   },
                   {
-                    "containerPort": 8080,
-                    "name": "gateway"
-                  },
-                  {
-                    "containerPort": 9090,
-                    "name": "metrics"
+                    "containerPort": 9465,
+                    "name": "metrics",
+                    "protocol": "TCP"
                   }
                 ],
                 "resources": {
@@ -90,16 +105,16 @@ Request {
                 "volumeMounts": [
                   {
                     "mountPath": "/data/ipfs",
-                    "name": "cas-ipfs-data"
+                    "name": "ipfs-data"
                   }
                 ]
               }
             ],
             "volumes": [
               {
-                "name": "cas-ipfs-data",
+                "name": "ipfs-data",
                 "persistentVolumeClaim": {
-                  "claimName": "cas-ipfs-data"
+                  "claimName": "ipfs-data"
                 }
               }
             ]
@@ -110,7 +125,7 @@ Request {
             "apiVersion": "v1",
             "kind": "PersistentVolumeClaim",
             "metadata": {
-              "name": "cas-ipfs-data"
+              "name": "ipfs-data"
             },
             "spec": {
               "accessModes": [

--- a/operator/src/network/testdata/default_stubs/ceramic_stateful_set
+++ b/operator/src/network/testdata/default_stubs/ceramic_stateful_set
@@ -50,7 +50,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",
@@ -155,10 +155,6 @@ Request {
                     "value": "0"
                   },
                   {
-                    "name": "CERAMIC_ONE_METRICS",
-                    "value": "true"
-                  },
-                  {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
@@ -176,7 +172,7 @@ Request {
                   },
                   {
                     "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,tracing_actix_web=debug,quinn_proto=error"
+                    "value": "info,ceramic_one=debug,multipart=error"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -242,7 +238,7 @@ Request {
                   },
                   {
                     "name": "CERAMIC_NETWORK_TOPIC",
-                    "value": "/ceramic/local-keramik"
+                    "value": "/ceramic/local-0"
                   },
                   {
                     "name": "ETH_RPC_URL",

--- a/operator/src/simulation/spec.rs
+++ b/operator/src/simulation/spec.rs
@@ -19,7 +19,7 @@ pub struct SimulationSpec {
     pub scenario: String,
     /// Number of users
     pub users: u32,
-    /// Time to run simulation
+    /// Time in seconds to run the simulation
     pub run_time: u32,
     /// Image for all jobs created by the simulation.
     pub image: Option<String>,


### PR DESCRIPTION
The changes to rust-ceramic that use the network to connect to a predefined set of nodes based on the network meant that the CAS ipfs node was connecting to clay and therefore the rest of the nodes would learn about and connect to clay.

This changes is so that CAS uses a shared IPFS spec with Ceramic, thus fixing the bug that the CAS ipfs network was not being configured.

This is a breaking change in that the pubsub_topic is no longer needed and the ipfs_resource_limits is removed from CAS as its not part of `ipfs` spec directly.