### PR TITLE
fix: env var changed for cas metrics

### DIFF
--- a/operator/src/network/cas.rs
+++ b/operator/src/network/cas.rs
@@ -259,7 +259,7 @@ pub fn cas_stateful_set_spec(
                 ..Default::default()
             },
             EnvVar {
-                name: "METRICS_PROMETHEUS_PORT".to_owned(),
+                name: "METRICS_PORT".to_owned(),
                 value: Some("9464".to_owned()),
                 ..Default::default()
             },

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -3079,7 +3079,7 @@ mod tests {
                        "spec": {
             @@ -132,6 +138,22 @@
                                {
-                                 "name": "METRICS_PROMETHEUS_PORT",
+                                 "name": "METRICS_PORT",
                                  "value": "9464"
             +                  },
             +                  {

--- a/operator/src/network/testdata/default_stubs/cas_stateful_set
+++ b/operator/src/network/testdata/default_stubs/cas_stateful_set
@@ -130,7 +130,7 @@ Request {
                     "value": "8081"
                   },
                   {
-                    "name": "METRICS_PROMETHEUS_PORT",
+                    "name": "METRICS_PORT",
                     "value": "9464"
                   }
                 ],


### PR DESCRIPTION
Upstream changed the env here https://github.com/ceramicnetwork/ceramic-anchor-service/pull/1177
