### PR TITLE
feat: Add workflow to build images on demand

### DIFF
--- a/.github/workflows/on-demand-build-images.yaml
+++ b/.github/workflows/on-demand-build-images.yaml
@@ -1,0 +1,40 @@
+name: On demand Docker Image Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        description: "Tag name will be prefaced with 'on-demand-'."
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Public ECR
+        uses: docker/login-action@v2
+        with:
+            registry: public.ecr.aws
+            username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        env:
+            AWS_REGION: us-east-1
+      - name: Set Final Tag
+        run: echo "TAG=on-demand-${{ inputs.tag_name }}" >> .env
+
+      - name: Build Docker Image
+        run: |
+          docker buildx build --load -t 3box/keramik-runner:$TAG --target runner .
+          docker push public.ecr.aws/r5b3e0r5/3box/keramik-runner:$TAG
+
+      - name: Build Docker Image
+        run: |
+          docker buildx build --load -t 3box/keramik-operator:$TAG --target operator .
+          docker push public.ecr.aws/r5b3e0r5/3box/keramik-operator:$TAG
+
+      - name: Print Image ID
+        run: |
+          echo public.ecr.aws/r5b3e0r5/3box/keramik-runner:$TAG
+          echo public.ecr.aws/r5b3e0r5/3box/keramik-operator:$TAG
+


### PR DESCRIPTION
The GCP route doesn't work with our Dockerfile mount cacheing (they have their own cacheing) so this seems easier.