### PR TITLE
docs: Added Documentation for enabling Recon with rust-ceramic

### DIFF
--- a/keramik/src/advanced_configuration.md
+++ b/keramik/src/advanced_configuration.md
@@ -149,7 +149,6 @@ spec:
   ceramic:
     - ipfs:
         rust:
-          imagePullPolicy: Always
           env:
             CERAMIC_ONE_RECON: "true"
 ```

--- a/keramik/src/advanced_configuration.md
+++ b/keramik/src/advanced_configuration.md
@@ -132,3 +132,24 @@ spec:
       cpu: "250m"
       memory: "1Gi"
 ```
+
+# Enabling Recon
+
+You can also use Recon for reconciliation by setting 'CERAMIC_ONE_RECON' env variable to true. 
+
+```yaml
+# network configuration
+---
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: small
+spec:
+  replicas: 2
+  ceramic:
+    - ipfs:
+        rust:
+          imagePullPolicy: Always
+          env:
+            CERAMIC_ONE_RECON: "true"
+```


### PR DESCRIPTION
Description : 
Added documentation on how to enable recon with rust-ceramic. I have added how to do this under Advanced configurations in the documentation. 

Testing : 
Test Case : Check if the daemon is running with `recon` flag set to true, when a network is configured using the spec mentioned in advance configuration.
Output of logs : Recon flag is set to true in the daemon configurations
```
samikas@samikas-mbp keramik % kubectl logs ceramic-0-0 -c ipfs -n keramik-test-env

  2024-01-05T18:26:41.799740Z  INFO ceramic_one: service__name: "ceramic-one", version: "0.9.0", build: "cargo:0.9.0", instance_id: "fallacious-representative", exe_hash: "uEiD9nHuu_MfKyTiRLNvR9MNhBhGTmj5klpZaY_aX99PpOQ"
    at one/src/lib.rs:345

  2024-01-05T18:26:41.876499Z DEBUG ceramic_one: using daemon options, opts: DaemonOpts { bind_address: "0.0.0.0:5001", swarm_addresses: ["/ip4/0.0.0.0/tcp/4001"], extra_ceramic_peer_addresses: [], store_dir: Some("/data/ipfs"), metrics_bind_address: "0.0.0.0:9465", metrics: false, tracing: false, network: Local, local_network_id: Some(0), mdns: false, recon: true, disable_autonat: false, log_format: MultiLine, max_conns_out: 2000, max_conns_in: 2000, max_conns_pending_out: 256, max_conns_pending_in: 256, max_conns_per_peer: 8, idle_conns_timeout_ms: 30000, kademlia_replication: 6, kademlia_parallelism: 1, kademlia_query_timeout_secs: 60, kademlia_provider_publication_interval_secs: 43200, kademlia_provider_record_ttl_secs: 86400 }
    at one/src/lib.rs:352
```
