### PR TITLE
feat: Add Recon event sync scenarios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,7 +669,7 @@ dependencies = [
  "did-pkh",
  "hex",
  "int-enum",
- "libp2p-identity",
+ "libp2p-identity 0.1.3",
  "minicbor",
  "multibase 0.9.1",
  "once_cell",
@@ -674,12 +683,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ceramic-core"
+version = "0.9.0"
+source = "git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main#58dc5b684ad57aecb38e7ea65ed7744a2bc3ca77"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.21.4",
+ "cid 0.10.1",
+ "did-method-key",
+ "did-pkh",
+ "hex",
+ "int-enum",
+ "libp2p-identity 0.2.3",
+ "minicbor",
+ "multibase 0.9.1",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_bytes",
+ "serde_ipld_dagcbor",
+ "serde_json",
+ "ssi 0.7.0",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "ceramic-event"
 version = "0.1.0"
 source = "git+https://github.com/3box/rust-ceramic?branch=main#ffc75b3af3bc25216f0dd54b9bd64c8a1353f7f9"
 dependencies = [
  "anyhow",
- "ceramic-core",
+ "ceramic-core 0.1.0",
  "multibase 0.9.1",
  "multihash 0.17.0",
  "once_cell",
@@ -761,6 +796,7 @@ dependencies = [
  "multibase 0.9.1",
  "multihash 0.18.1",
  "serde",
+ "serde_bytes",
  "unsigned-varint",
 ]
 
@@ -1390,7 +1426,7 @@ checksum = "074c4ae82880d60a25048cd3bf2e8aaaa881922d7c73fbb9ec29fc67fa0d33e4"
 dependencies = [
  "async-trait",
  "bech32",
- "bs58",
+ "bs58 0.4.0",
  "chrono",
  "iref",
  "serde",
@@ -2670,7 +2706,7 @@ dependencies = [
  "mockall",
  "multiaddr",
  "multibase 0.9.1",
- "multihash 0.17.0",
+ "multihash 0.18.1",
  "opentelemetry",
  "rand 0.8.5",
  "reqwest",
@@ -2691,14 +2727,14 @@ name = "keramik-runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ceramic-core 0.9.0",
  "ceramic-http-client",
- "cid 0.9.0",
  "clap",
  "goose",
  "keramik-common",
  "libipld 0.16.0",
  "multibase 0.9.1",
- "multihash 0.17.0",
+ "multihash 0.18.1",
  "opentelemetry",
  "rand 0.8.5",
  "redis",
@@ -3100,11 +3136,28 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276bb57e7af15d8f100d3c11cbdd32c6752b7eef4ba7a18ecf464972c07abcce"
 dependencies = [
- "bs58",
+ "bs58 0.4.0",
  "ed25519-dalek 2.0.0",
  "log",
  "multiaddr",
  "multihash 0.17.0",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "sha2 0.10.7",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-identity"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686e73aff5e23efbb99bc85340ea6fd8686986aa7b283a881ba182cfca535ca9"
+dependencies = [
+ "bs58 0.5.0",
+ "ed25519-dalek 2.0.0",
+ "log",
+ "multihash 0.19.1",
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.7",
@@ -3393,8 +3446,20 @@ dependencies = [
  "core2",
  "digest 0.10.7",
  "multihash-derive",
+ "serde",
+ "serde-big-array",
  "sha2 0.10.7",
  "sha3",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
+dependencies = [
+ "core2",
  "unsigned-varint",
 ]
 
@@ -5128,7 +5193,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2c479690955bebece0279a5b1ab9d7d584402caed9f56ecec346d0bc63661f"
 dependencies = [
- "bs58",
+ "bs58 0.4.0",
  "ssi-jwk",
  "thiserror",
 ]
@@ -5156,7 +5221,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f41a12b15af9dce950a24a3295a2540be3b8500467621e31a97ddbe7618a5c8"
 dependencies = [
- "bs58",
+ "bs58 0.4.0",
  "digest 0.9.0",
  "k256",
  "keccak-hash",
@@ -5174,7 +5239,7 @@ checksum = "62e3c375b0fb2129c691e65e776c9105290ade34b56f39755f4f9c40ba98e41c"
 dependencies = [
  "anyhow",
  "async-trait",
- "bs58",
+ "bs58 0.4.0",
  "chrono",
  "derive_builder",
  "hex",
@@ -5221,7 +5286,7 @@ checksum = "df3c376df0c00621f6d8de45249e901cf2b3868bef84cf785fbcbce62842d815"
 dependencies = [
  "base64 0.12.3",
  "blake2b_simd 0.5.11",
- "bs58",
+ "bs58 0.4.0",
  "ed25519-dalek 1.0.1",
  "getrandom 0.2.10",
  "k256",
@@ -5286,7 +5351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de930bb18e3ed3c1f7b0a2b2b4fdba2887dffff34bb5f44b9967a983fea2d60c"
 dependencies = [
  "async-trait",
- "bs58",
+ "bs58 0.4.0",
  "chrono",
  "grdf",
  "hex",
@@ -5322,7 +5387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb057ad335a08d78deca3a7cf8f8393087ca99d64c038e97ff844ea66fbd475"
 dependencies = [
  "async-trait",
- "bs58",
+ "bs58 0.4.0",
  "chrono",
  "grdf",
  "hex",
@@ -5369,7 +5434,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b57d919e20d214253a9a8dbc5f3b08ff555364934d99a09c828becab27a823"
 dependencies = [
- "bs58",
+ "bs58 0.4.0",
  "ed25519-dalek 1.0.1",
  "ssi-jwk",
  "ssi-jws",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,6 +2727,7 @@ name = "keramik-runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "ceramic-core 0.9.0",
  "ceramic-http-client",
  "clap",
@@ -2745,6 +2746,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-log",
+ "tracing-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,6 +1601,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2743,10 +2752,11 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "test-log",
  "tokio",
  "tracing",
  "tracing-log",
- "tracing-test",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5675,6 +5685,27 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "test-log"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6159ab4116165c99fc88cce31f99fa2c9dbe08d3691cb38da02fc3b45f357d2b"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba277e77219e9eea169e8508942db1bf5d8a41ff2db9b20aab5a5aadc9fa25d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,13 @@ resolver = "2"
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
 console-subscriber = "0.2"
+ceramic-core = { git = "https://github.com/ceramicnetwork/rust-ceramic.git", branch = "main"}
 env_logger = "0.10.0"
 expect-patch = { path = "./expect-patch/" }
 keramik-common = { path = "./common/", default-features = false }
 multiaddr = "0.17"
 multibase = "0.9.1"
-multihash = "0.17"
+multihash = "0.18"
 opentelemetry = { version = "0.18", features = [
     "metrics",
     "trace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1"
+async-trait = "0.1"
 clap = { version = "4", features = ["derive", "env"] }
 console-subscriber = "0.2"
 ceramic-core = { git = "https://github.com/ceramicnetwork/rust-ceramic.git", branch = "main"}

--- a/common/src/peer_info.rs
+++ b/common/src/peer_info.rs
@@ -37,6 +37,14 @@ impl Peer {
             Peer::Ipfs(p) => p.p2p_addrs.as_slice(),
         }
     }
+
+    /// Report the Ceramic API address of the peer. None if this is not a ceramic peer.
+    pub fn ceramic_addr(&self) -> Option<&str> {
+        match self {
+            Peer::Ceramic(p) => Some(&p.ceramic_addr),
+            Peer::Ipfs(_) => None,
+        }
+    }
 }
 
 /// Describes a peer that participates via Ceramic protocols.

--- a/keramik/src/advanced_configuration.md
+++ b/keramik/src/advanced_configuration.md
@@ -47,7 +47,7 @@ spec:
   replicas: 2
   ceramic:
     - env:
-        CERAMIC_PUBSUB_QPS_LIMIT: 500
+        CERAMIC_PUBSUB_QPS_LIMIT: "500"
 ```
 
 # Disabling AWS Functionality

--- a/keramik/src/simulation.md
+++ b/keramik/src/simulation.md
@@ -7,7 +7,8 @@ To run a simulation, first define a simulation. Available simulation types are
 - `ceramic-write-only` - A simulation that only performs updates on two different streams
 - `ceramic-new-streams` - A simulation that only creates new streams
 - `ceramic-model-reuse` - A simulation that reuses the same model and queries instances across workers
-- `event-id-sync` - A simulation that creates events for Recon to sync at a fixed rate (~300/s by default). Only designed for a 2 node network.
+- `recon-event-key-sync` - A simulation that creates event keys for Recon to sync at a fixed rate (~300/s by default). Designed for a 2 node network but should work on any.
+- `recon-event-sync` - A simulation that creates events for Recon to sync at a fixed rate (~300/s by default). Designed for a 2 node network but should work on any. Choosing between recon scenarios depends on what version of rust-ceramic you have. Some versions support keys only, some support key/value (maybe we'll support both someday). If you're not sure, try this one first.
 
 Using one of these scenarios, we can then define the configuration for that scenario:
 

--- a/keramik/src/simulation.md
+++ b/keramik/src/simulation.md
@@ -7,7 +7,7 @@ To run a simulation, first define a simulation. Available simulation types are
 - `ceramic-write-only` - A simulation that only performs updates on two different streams
 - `ceramic-new-streams` - A simulation that only creates new streams
 - `ceramic-model-reuse` - A simulation that reuses the same model and queries instances across workers
-- `steady-event-id-sync` - A simulation that creates events for Recon to sync at a fixed rate (~300/s by default). Only designed for a 2 node network.
+- `event-id-sync` - A simulation that creates events for Recon to sync at a fixed rate (~300/s by default). Only designed for a 2 node network.
 
 Using one of these scenarios, we can then define the configuration for that scenario:
 

--- a/keramik/src/simulation.md
+++ b/keramik/src/simulation.md
@@ -6,6 +6,8 @@ To run a simulation, first define a simulation. Available simulation types are
 - `ceramic-simple` - A simple simulation that writes and reads events to two different streams, a small and large model
 - `ceramic-write-only` - A simulation that only performs updates on two different streams
 - `ceramic-new-streams` - A simulation that only creates new streams
+- `ceramic-model-reuse` - A simulation that reuses the same model and queries instances across workers
+- `steady-event-id-sync` - A simulation that creates events for Recon to sync at a fixed rate (~300/s by default). Only designed for a 2 node network.
 
 Using one of these scenarios, we can then define the configuration for that scenario:
 
@@ -26,7 +28,7 @@ spec:
 
 If you want to run it against a defined network, set the namespace to the same as the network. in this example the
 namespace is set to the same network applied when [the network was setup](./setup_network.md).
-Additionally, you can define the scenario you want to run, the number of users, and the number of minutes it will run.
+Additionally, you can define the scenario you want to run, the number of users to run for each node, and the number of minutes it will run.
 
 Before running the simulation make sure the `network` is ready.
 

--- a/operator/src/network/ipfs_rpc.rs
+++ b/operator/src/network/ipfs_rpc.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 use keramik_common::peer_info::IpfsPeerInfo;
-use multiaddr::{Multiaddr, multihash::Multihash, Protocol};
+use multiaddr::{multihash::Multihash, Multiaddr, Protocol};
 use serde::Deserialize;
 
 /// Define the behavior we consume from the IPFS RPC API.

--- a/operator/src/network/ipfs_rpc.rs
+++ b/operator/src/network/ipfs_rpc.rs
@@ -1,8 +1,7 @@
 use anyhow::{anyhow, bail, Result};
 use async_trait::async_trait;
 use keramik_common::peer_info::IpfsPeerInfo;
-use multiaddr::{Multiaddr, Protocol};
-use multihash::Multihash;
+use multiaddr::{Multiaddr, multihash::Multihash, Protocol};
 use serde::Deserialize;
 
 /// Define the behavior we consume from the IPFS RPC API.

--- a/operator/src/simulation/controller.rs
+++ b/operator/src/simulation/controller.rs
@@ -173,6 +173,7 @@ async fn reconcile(
         nonce: status.nonce,
         job_image_config: job_image_config.clone(),
         throttle_requests: spec.throttle_requests,
+        success_request_target: spec.success_request_target,
     };
 
     apply_manager(cx.clone(), &ns, simulation.clone(), manager_config).await?;

--- a/operator/src/simulation/controller.rs
+++ b/operator/src/simulation/controller.rs
@@ -808,6 +808,69 @@ mod tests {
                              ],
                              "image": "public.ecr.aws/r5b3e0r5/3box/keramik-runner:latest",
         "#]]);
+        stub.worker_jobs[0].patch(expect![[r#"
+        --- original
+        +++ modified
+        @@ -70,6 +70,10 @@
+                           {
+                             "name": "DID_PRIVATE_KEY",
+                             "value": "86dce513cf0a37d4acd6d2c2e00fe4b95e0e655ca51e1a890808f5fa6f4fe65a"
+        +                  },
+        +                  {
+        +                    "name": "SIMULATE_THROTTLE_REQUESTS",
+        +                    "value": "100"
+                           }
+                         ],
+                         "image": "public.ecr.aws/r5b3e0r5/3box/keramik-runner:latest",
+    "#]]);
+        stub.worker_jobs[1].patch(expect![[r#"
+        --- original
+        +++ modified
+        @@ -70,6 +70,10 @@
+                           {
+                             "name": "DID_PRIVATE_KEY",
+                             "value": "86dce513cf0a37d4acd6d2c2e00fe4b95e0e655ca51e1a890808f5fa6f4fe65a"
+        +                  },
+        +                  {
+        +                    "name": "SIMULATE_THROTTLE_REQUESTS",
+        +                    "value": "100"
+                           }
+                         ],
+                         "image": "public.ecr.aws/r5b3e0r5/3box/keramik-runner:latest",
+    "#]]);
+        let mocksrv = stub.run(fakeserver);
+        reconcile(Arc::new(simulation), testctx)
+            .await
+            .expect("reconciler");
+        timeout_after_1s(mocksrv).await;
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn reconcile_simulate_request_target() {
+        let mock_rpc_client = MockIpfsRpcClientTest::new();
+        let (testctx, api_handle) = Context::test(mock_rpc_client);
+        let fakeserver = ApiServerVerifier::new(api_handle);
+        let simulation = Simulation::test().with_spec(SimulationSpec {
+            success_request_target: Some(280),
+            ..Default::default()
+        });
+        let mut stub = Stub::default();
+        stub.manager_job.patch(expect![[r#"
+            --- original
+            +++ modified
+            @@ -74,6 +74,10 @@
+                               {
+                                 "name": "DID_PRIVATE_KEY",
+                                 "value": "86dce513cf0a37d4acd6d2c2e00fe4b95e0e655ca51e1a890808f5fa6f4fe65a"
+            +                  },
+            +                  {
+            +                    "name": "SIMULATE_TARGET_REQUESTS",
+            +                    "value": "280"
+                               }
+                             ],
+                             "image": "public.ecr.aws/r5b3e0r5/3box/keramik-runner:latest",
+        "#]]);
         let mocksrv = stub.run(fakeserver);
         reconcile(Arc::new(simulation), testctx)
             .await

--- a/operator/src/simulation/controller.rs
+++ b/operator/src/simulation/controller.rs
@@ -332,6 +332,7 @@ async fn apply_n_workers(
             target_peer: i,
             nonce,
             job_image_config: job_image_config.clone(),
+            throttle_requests: spec.throttle_requests,
         };
 
         apply_job(

--- a/operator/src/simulation/manager.rs
+++ b/operator/src/simulation/manager.rs
@@ -35,6 +35,7 @@ pub struct ManagerConfig {
     pub throttle_requests: Option<usize>,
     pub nonce: u32,
     pub job_image_config: JobImageConfig,
+    pub success_request_target: Option<usize>,
 }
 
 pub fn manager_job_spec(config: ManagerConfig) -> JobSpec {
@@ -101,6 +102,13 @@ pub fn manager_job_spec(config: ManagerConfig) -> JobSpec {
         env_vars.push(EnvVar {
             name: "SIMULATE_THROTTLE_REQUESTS".to_owned(),
             value: Some(throttle_requests.to_string()),
+            ..Default::default()
+        })
+    }
+    if let Some(success_request_target) = config.success_request_target {
+        env_vars.push(EnvVar {
+            name: "SIMULATE_TARGET_REQUESTS".to_owned(),
+            value: Some(success_request_target.to_string()),
             ..Default::default()
         })
     }

--- a/operator/src/simulation/spec.rs
+++ b/operator/src/simulation/spec.rs
@@ -25,8 +25,12 @@ pub struct SimulationSpec {
     pub image: Option<String>,
     /// Pull policy for image.
     pub image_pull_policy: Option<String>,
-    /// Throttle requests (per second) for a simulation
+    /// Throttle requests (per second) for a simulation. Currently on a per-worker basis.
     pub throttle_requests: Option<usize>,
+    /// Request target for the scenario to be a success. Scenarios can use this to
+    /// validate throughput and correctness before returning. The exact definition is
+    /// left to the scenario (requests per second, total requests, rps/node etc).
+    pub success_request_target: Option<usize>,
 }
 
 /// Current status of a simulation.

--- a/operator/src/simulation/worker.rs
+++ b/operator/src/simulation/worker.rs
@@ -17,9 +17,73 @@ pub struct WorkerConfig {
     pub target_peer: u32,
     pub nonce: u32,
     pub job_image_config: JobImageConfig,
+    pub throttle_requests: Option<usize>,
 }
 
 pub fn worker_job_spec(config: WorkerConfig) -> JobSpec {
+    let mut env_vars = vec![
+        EnvVar {
+            name: "REDIS_ENDPOINT".to_owned(),
+            value: Some("http://redis:6379".to_owned()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "RUNNER_OTLP_ENDPOINT".to_owned(),
+            value: Some("http://otel:4317".to_owned()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "RUST_LOG".to_owned(),
+            value: Some("info,keramik_runner=trace".to_owned()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "RUST_BACKTRACE".to_owned(),
+            value: Some("1".to_owned()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "SIMULATE_SCENARIO".to_owned(),
+            value: Some(config.scenario.to_owned()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "SIMULATE_TARGET_PEER".to_owned(),
+            value: Some(config.target_peer.to_string()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "SIMULATE_PEERS_PATH".to_owned(),
+            value: Some("/keramik-peers/peers.json".to_owned()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "SIMULATE_NONCE".to_owned(),
+            value: Some(config.nonce.to_string()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "DID_KEY".to_owned(),
+            value: Some("did:key:z6Mkqn5jbycThHcBtakJZ8fHBQ2oVRQhXQEdQk5ZK2NDtNZA".to_owned()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "DID_PRIVATE_KEY".to_owned(),
+            value: Some(
+                "86dce513cf0a37d4acd6d2c2e00fe4b95e0e655ca51e1a890808f5fa6f4fe65a".to_owned(),
+            ),
+            ..Default::default()
+        },
+    ];
+
+    if let Some(throttle_requests) = config.throttle_requests {
+        env_vars.push(EnvVar {
+            name: "SIMULATE_THROTTLE_REQUESTS".to_owned(),
+            value: Some(throttle_requests.to_string()),
+            ..Default::default()
+        })
+    }
+
     JobSpec {
         backoff_limit: Some(4),
         template: PodTemplateSpec {
@@ -39,64 +103,7 @@ pub fn worker_job_spec(config: WorkerConfig) -> JobSpec {
                         "/usr/bin/keramik-runner".to_owned(),
                         "simulate".to_owned(),
                     ]),
-                    env: Some(vec![
-                        EnvVar {
-                            name: "REDIS_ENDPOINT".to_owned(),
-                            value: Some("http://redis:6379".to_owned()),
-                            ..Default::default()
-                        },
-                        EnvVar {
-                            name: "RUNNER_OTLP_ENDPOINT".to_owned(),
-                            value: Some("http://otel:4317".to_owned()),
-                            ..Default::default()
-                        },
-                        EnvVar {
-                            name: "RUST_LOG".to_owned(),
-                            value: Some("info,keramik_runner=trace".to_owned()),
-                            ..Default::default()
-                        },
-                        EnvVar {
-                            name: "RUST_BACKTRACE".to_owned(),
-                            value: Some("1".to_owned()),
-                            ..Default::default()
-                        },
-                        EnvVar {
-                            name: "SIMULATE_SCENARIO".to_owned(),
-                            value: Some(config.scenario.to_owned()),
-                            ..Default::default()
-                        },
-                        EnvVar {
-                            name: "SIMULATE_TARGET_PEER".to_owned(),
-                            value: Some(config.target_peer.to_string()),
-                            ..Default::default()
-                        },
-                        EnvVar {
-                            name: "SIMULATE_PEERS_PATH".to_owned(),
-                            value: Some("/keramik-peers/peers.json".to_owned()),
-                            ..Default::default()
-                        },
-                        EnvVar {
-                            name: "SIMULATE_NONCE".to_owned(),
-                            value: Some(config.nonce.to_string()),
-                            ..Default::default()
-                        },
-                        EnvVar {
-                            name: "DID_KEY".to_owned(),
-                            value: Some(
-                                "did:key:z6Mkqn5jbycThHcBtakJZ8fHBQ2oVRQhXQEdQk5ZK2NDtNZA"
-                                    .to_owned(),
-                            ),
-                            ..Default::default()
-                        },
-                        EnvVar {
-                            name: "DID_PRIVATE_KEY".to_owned(),
-                            value: Some(
-                                "86dce513cf0a37d4acd6d2c2e00fe4b95e0e655ca51e1a890808f5fa6f4fe65a"
-                                    .to_owned(),
-                            ),
-                            ..Default::default()
-                        },
-                    ]),
+                    env: Some(env_vars),
                     volume_mounts: Some(vec![VolumeMount {
                         mount_path: "/keramik-peers".to_owned(),
                         name: "keramik-peers".to_owned(),

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+ceramic-core.workspace = true
 ceramic-http-client = { git = "https://github.com/3box/ceramic-http-client-rs.git", branch = "main", default-features = false }
 #ceramic-http-client = { path = "../../ceramic-http-client-rs", default-features = false }
-cid = "0.9"
 clap.workspace = true
 goose = { version = "0.16", features = ["gaggle"] }
 keramik-common = { workspace = true, features = ["telemetry", "tokio-console"] }

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 ceramic-core.workspace = true
 ceramic-http-client = { git = "https://github.com/3box/ceramic-http-client-rs.git", branch = "main", default-features = false }
 #ceramic-http-client = { path = "../../ceramic-http-client-rs", default-features = false }
@@ -27,3 +28,6 @@ tokio.workspace = true
 tracing-log.workspace = true
 tracing.workspace = true
 multibase.workspace = true
+
+[dev-dependencies]
+tracing-test = "0.2"

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -27,7 +27,8 @@ serde_json.workspace = true
 tokio.workspace = true
 tracing-log.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 multibase.workspace = true
 
 [dev-dependencies]
-tracing-test = "0.2"
+test-log = "0.2"

--- a/runner/src/bootstrap.rs
+++ b/runner/src/bootstrap.rs
@@ -6,7 +6,10 @@ use keramik_common::peer_info::Peer;
 use rand::seq::IteratorRandom;
 use tracing::{debug, error};
 
-use crate::utils::{connect_peers, parse_peers_info};
+use crate::{
+    utils::{connect_peers, parse_peers_info},
+    CommandResult,
+};
 
 /// Options to Bootstrap command
 #[derive(Args, Debug)]
@@ -41,7 +44,7 @@ impl Default for Method {
 }
 
 #[tracing::instrument]
-pub async fn bootstrap(opts: Opts) -> Result<()> {
+pub async fn bootstrap(opts: Opts) -> Result<CommandResult> {
     let peers = parse_peers_info(opts.peers).await?;
     // Bootstrap peers according to the given method.
     // Methods should not assume that peer indexes are consecutive nor that they start at zero.
@@ -50,7 +53,7 @@ pub async fn bootstrap(opts: Opts) -> Result<()> {
         Method::Random => random(opts.n, &peers).await?,
         Method::Sentinel => sentinel(opts.n, &peers).await?,
     }
-    Ok(())
+    Ok(CommandResult::Success)
 }
 
 #[tracing::instrument(skip(peers), fields(peers.len = peers.len()))]

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -55,6 +55,7 @@ impl Command {
 /// This is primarily used to differentiate between a simulation failure and a failure to run the command.
 /// Both should return a non-zero exit code, but the former should still report and clean up since the command
 /// executed successfully, it just didn't pass thresholds or whatever correctness requirements we enforce.
+#[derive(Debug)]
 pub enum CommandResult {
     /// Command completed successfully
     Success,

--- a/runner/src/scenario/ceramic/event_id_sync.rs
+++ b/runner/src/scenario/ceramic/event_id_sync.rs
@@ -1,0 +1,171 @@
+use crate::scenario::ceramic::model_reuse::{
+    get_model_id, set_model_id, ModelReuseLoadTestUserData,
+};
+use crate::scenario::ceramic::models;
+use crate::scenario::ceramic::util::setup_model;
+use crate::scenario::get_redis_client;
+use ceramic_core::{Cid, EventId};
+use ceramic_http_client::{CeramicHttpClient, ModelAccountRelation, ModelDefinition};
+use goose::prelude::*;
+use libipld::cid;
+use multihash::{Code, MultihashDigest};
+use reqwest::Url;
+use std::{sync::Arc, time::Duration};
+use tracing::{info, instrument};
+
+use super::util::goose_error;
+use super::{CeramicClient, Credentials};
+
+const MODEL_ID_KEY: &str = "event_id_sync_model_id";
+
+fn should_request_events() -> bool {
+    goose::get_worker_id() == 1
+}
+
+// accept option as goose manager builds the scenario as well, but doesn't need any peers and won't run it so it will always be Some in execution
+pub async fn steady_sync_scenario(ipfs_peer_addr: Option<String>) -> Result<Scenario, GooseError> {
+    let ipfs_addr: Url = ipfs_peer_addr
+        .map(|u| u.parse().unwrap())
+        .expect("missing ipfs peer address in event ID scenario");
+    let creds = Credentials::from_env().await.map_err(goose_error)?;
+    let cli = CeramicHttpClient::new(creds.signer);
+    let redis_cli = get_redis_client().await?;
+
+    let test_start = Transaction::new(Arc::new(move |user| {
+        Box::pin(setup(
+            user,
+            cli.clone(),
+            redis_cli.clone(),
+            ipfs_addr.clone(),
+        ))
+    }))
+    .set_name("setup")
+    .set_on_start();
+
+    let sync_event_id = transaction!(sync_event_id).set_name("sync_event_id");
+
+    Ok(scenario!("SteadyEventIDSync")
+        .register_transaction(test_start)
+        .register_transaction(sync_event_id))
+}
+
+// send subscription to each node
+// node A should send 1M events to node B
+// node A must report how long it took to send 1M events
+// node B must report how long it took from first request to last event
+#[instrument(skip_all, fields(user.index = user.weighted_users_index), ret)]
+async fn setup(
+    user: &mut GooseUser,
+    cli: CeramicClient,
+    redis_cli: redis::Client,
+    ipfs_peer_addr: Url,
+) -> TransactionResult {
+    let mut conn = redis_cli.get_async_connection().await.unwrap();
+    let model_id = if should_request_events() {
+        info!("creating model for event ID sync test");
+        let small_model = match ModelDefinition::new::<models::SmallModel>(
+            "load_test_small_model",
+            ModelAccountRelation::List,
+        ) {
+            Ok(model) => model,
+            Err(e) => {
+                tracing::error!("failed to create model: {}", e);
+                panic!("failed to create model: {}", e);
+            }
+        };
+        let model_id = match setup_model(user, &cli, small_model).await {
+            Ok(model_id) => model_id,
+            Err(e) => {
+                tracing::error!("failed to setup model: {:?}", e);
+                return Err(e);
+            }
+        };
+        set_model_id(&mut conn, &model_id, MODEL_ID_KEY).await;
+        model_id
+    } else {
+        get_model_id(&mut conn, MODEL_ID_KEY).await
+    };
+
+    tracing::debug!(%model_id, "syncing model");
+
+    let user_data = ModelReuseLoadTestUserData {
+        cli,
+        redis_cli,
+        model_id,
+    };
+    user.set_session_data(user_data);
+    user.base_url = Some(ipfs_peer_addr); // Recon is only available on IPFS address right now
+
+    let _subscribed_to_models = user
+        .get_request_builder(
+            &GooseMethod::Get,
+            "/ceramic/subscribe/model/%7Bmodel%7D?limit=1",
+        )?
+        .timeout(std::time::Duration::from_secs(5))
+        .send()
+        .await?;
+
+    Ok(())
+}
+
+async fn sync_event_id(user: &mut GooseUser) -> TransactionResult {
+    if !should_request_events() {
+        // this inflates the scenario/transaction metrics, but it doesn't affect the request metrics
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        Ok(())
+    } else {
+        let user_data: &ModelReuseLoadTestUserData = user
+            .get_session_data()
+            .expect("we are missing sync_event_id user data");
+
+        // eventId needs to be a multibase encoded string for the API to accept it
+        let event_id = format!("F{}", random_event_id(&user_data.model_id.to_string()));
+        let event_key_body = serde_json::json!({"eventId": event_id});
+        tracing::debug!("sync_event_id body: {:?}", event_key_body);
+        let request_builder = user
+            .get_request_builder(&GooseMethod::Post, "/ceramic/events")?
+            .timeout(Duration::from_secs(1))
+            .json(&event_key_body);
+        let req = GooseRequest::builder()
+            .method(GooseMethod::Post)
+            .set_request_builder(request_builder)
+            .expect_status_code(204)
+            .build();
+        let mut goose = user.request(req).await?;
+        let resp = goose.response?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            user.set_failure(
+                "sync_event_id",
+                &mut goose.request,
+                None,
+                Some(&format!("Failed to add event ID: {}", event_id)),
+            )
+        }
+    }
+}
+
+fn random_cid() -> cid::Cid {
+    let mut data = [0u8; 8];
+    rand::Rng::fill(&mut rand::thread_rng(), &mut data);
+    let hash = Code::Sha2_256.digest(data.as_slice());
+    Cid::new_v1(0x00, hash)
+}
+
+const SORT_KEY: &str = "model";
+// hard code test controller in case we want to find/prune later
+const TEST_CONTROLLER: &str = "did:key:z6MkoFUppcKEVYTS8oVidrja94UoJTatNhnhxJRKF7NYPScS";
+
+fn random_event_id(sort_value: &str) -> ceramic_core::EventId {
+    let cid = random_cid();
+    EventId::new(
+        &ceramic_core::Network::Local(42),
+        SORT_KEY,
+        sort_value,
+        TEST_CONTROLLER,
+        &cid,
+        0,
+        &cid,
+    )
+}

--- a/runner/src/scenario/ceramic/event_id_sync.rs
+++ b/runner/src/scenario/ceramic/event_id_sync.rs
@@ -127,6 +127,8 @@ async fn setup(
 /// users do it so that we can generate a lot of events.
 async fn create_new_event(user: &mut GooseUser) -> TransactionResult {
     if !should_request_events() {
+        // No work is performed while awaiting on the sleep future to complete (from tokio::time::sleep docs)
+        // it's not high resolution but we don't need it to be since we're already waiting half a second
         tokio::time::sleep(Duration::from_millis(500)).await;
         Ok(())
     } else {
@@ -171,7 +173,7 @@ const TEST_CONTROLLER: &str = "did:key:z6MkoFUppcKEVYTS8oVidrja94UoJTatNhnhxJRKF
 fn random_event_id(sort_value: &str) -> ceramic_core::EventId {
     let cid = random_cid();
     EventId::new(
-        &ceramic_core::Network::Local(42),
+        &ceramic_core::Network::Local(0),
         SORT_KEY,
         sort_value,
         TEST_CONTROLLER,

--- a/runner/src/scenario/ceramic/mod.rs
+++ b/runner/src/scenario/ceramic/mod.rs
@@ -1,3 +1,4 @@
+pub mod event_id_sync;
 pub mod model_reuse;
 mod models;
 pub mod new_streams;

--- a/runner/src/scenario/ceramic/mod.rs
+++ b/runner/src/scenario/ceramic/mod.rs
@@ -1,8 +1,8 @@
-pub mod event_id_sync;
 pub mod model_reuse;
 mod models;
 pub mod new_streams;
 pub mod query;
+pub mod recon_sync;
 pub mod simple;
 pub mod util;
 pub mod write_only;

--- a/runner/src/scenario/ceramic/mod.rs
+++ b/runner/src/scenario/ceramic/mod.rs
@@ -2,21 +2,19 @@ pub mod model_reuse;
 mod models;
 pub mod new_streams;
 pub mod query;
+pub mod simple;
 pub mod util;
 pub mod write_only;
 
-use crate::goose_try;
-use crate::scenario::ceramic::util::{goose_error, setup_model, setup_model_instance};
 use ceramic_http_client::api::StreamsResponseOrError;
-use ceramic_http_client::ceramic_event::{DidDocument, JwkSigner, StreamId};
-use ceramic_http_client::{CeramicHttpClient, ModelAccountRelation, ModelDefinition};
-use goose::prelude::*;
+use ceramic_http_client::ceramic_event::{DidDocument, JwkSigner};
+use ceramic_http_client::CeramicHttpClient;
+
 use models::RandomModelInstance;
-use std::{sync::Arc, time::Duration};
-use tracing::instrument;
 
 pub type CeramicClient = CeramicHttpClient<JwkSigner>;
 
+#[derive(Clone)]
 pub struct Credentials {
     pub signer: JwkSigner,
     pub did: DidDocument,
@@ -29,210 +27,4 @@ impl Credentials {
         let signer = JwkSigner::new(did.clone(), &private_key).await?;
         Ok(Self { signer, did })
     }
-}
-
-pub struct LoadTestUserData {
-    cli: CeramicClient,
-    small_model_id: StreamId,
-    small_model_instance_id: StreamId,
-    large_model_id: StreamId,
-    large_model_instance_id: StreamId,
-}
-
-pub async fn scenario() -> Result<Scenario, GooseError> {
-    let creds = Credentials::from_env().await.map_err(goose_error)?;
-    let cli = CeramicHttpClient::new(creds.signer);
-
-    let setup_cli = cli;
-    let test_start = Transaction::new(Arc::new(move |user| {
-        Box::pin(setup(user, setup_cli.clone()))
-    }))
-    .set_name("setup")
-    .set_on_start();
-
-    let update_small_model = transaction!(update_small_model).set_name("update_small_model");
-
-    let get_small_model = transaction!(get_small_model).set_name("get_small_model");
-
-    let update_large_model = transaction!(update_large_model).set_name("update_large_model");
-
-    let get_large_model = transaction!(get_large_model).set_name("get_large_model");
-
-    Ok(scenario!("CeramicSimpleScenario")
-        // After each transactions runs, sleep randomly from 1 to 5 seconds.
-        .set_wait_time(Duration::from_secs(1), Duration::from_secs(5))?
-        .register_transaction(test_start)
-        .register_transaction(update_small_model)
-        .register_transaction(get_small_model)
-        .register_transaction(update_large_model)
-        .register_transaction(get_large_model))
-}
-
-#[instrument(skip_all, fields(user.index = user.weighted_users_index), ret)]
-async fn setup(user: &mut GooseUser, cli: CeramicClient) -> TransactionResult {
-    let small_model = ModelDefinition::new::<models::SmallModel>(
-        "load_test_small_model",
-        ModelAccountRelation::List,
-    )
-    .unwrap();
-    let small_model_id = setup_model(user, &cli, small_model).await?;
-    let small_model_instance_id =
-        setup_model_instance(user, &cli, &small_model_id, &models::SmallModel::random()).await?;
-    let large_model = ModelDefinition::new::<models::LargeModel>(
-        "load_test_large_model",
-        ModelAccountRelation::List,
-    )
-    .unwrap();
-    let large_model_id = setup_model(user, &cli, large_model).await?;
-    let large_model_instance_id =
-        setup_model_instance(user, &cli, &large_model_id, &models::LargeModel::random()).await?;
-
-    let user_data = LoadTestUserData {
-        cli,
-        small_model_id,
-        small_model_instance_id,
-        large_model_id,
-        large_model_instance_id,
-    };
-
-    user.set_session_data(user_data);
-
-    Ok(())
-}
-
-async fn update_small_model(user: &mut GooseUser) -> TransactionResult {
-    let (model, url, req) = {
-        let user_data: &LoadTestUserData = user.get_session_data_unchecked();
-        let model = user_data.small_model_id.clone();
-        let cli = &user_data.cli;
-        let streams_url = user.build_url(&format!(
-            "{}/{}",
-            cli.streams_endpoint(),
-            user_data.small_model_instance_id
-        ))?;
-        let req = GooseRequest::builder()
-            .method(GooseMethod::Get)
-            .set_request_builder(user.client.get(streams_url))
-            .expect_status_code(200)
-            .build();
-        let commits_url = user.build_url(cli.commits_endpoint())?;
-        (model, commits_url, req)
-    };
-    let resp = user.request(req).await?;
-    let resp: StreamsResponseOrError = resp.response?.json().await?;
-    let resp = resp.resolve("update_small_model_get").unwrap();
-
-    let req = {
-        let user_data: &LoadTestUserData = user.get_session_data_unchecked();
-        user_data
-            .cli
-            .create_replace_request(&model, &resp, &models::SmallModel::random())
-            .await
-            .unwrap()
-    };
-    let req = user.client.post(url).json(&req);
-    let mut goose = user
-        .request(
-            GooseRequest::builder()
-                .method(GooseMethod::Post)
-                .set_request_builder(req)
-                .expect_status_code(200)
-                .build(),
-        )
-        .await?;
-    let resp: StreamsResponseOrError = goose.response?.json().await?;
-    goose_try!(
-        user,
-        "update",
-        &mut goose.request,
-        resp.resolve("update_small_model")
-    )?;
-    Ok(())
-}
-
-async fn get_small_model(user: &mut GooseUser) -> TransactionResult {
-    let user_data: &LoadTestUserData = user.get_session_data_unchecked();
-    let cli: &CeramicClient = &user_data.cli;
-    let url = user.build_url(&format!(
-        "{}/{}",
-        cli.streams_endpoint(),
-        user_data.small_model_instance_id
-    ))?;
-    let mut goose = user.get(&url).await?;
-    let resp: StreamsResponseOrError = goose.response?.json().await?;
-    goose_try!(
-        user,
-        "get",
-        &mut goose.request,
-        resp.resolve("get_small_instance")
-    )?;
-    Ok(())
-}
-
-async fn update_large_model(user: &mut GooseUser) -> TransactionResult {
-    let (model, url, req) = {
-        let user_data: &LoadTestUserData = user.get_session_data_unchecked();
-        let model = user_data.large_model_id.clone();
-        let cli = &user_data.cli;
-        let streams_url = user.build_url(&format!(
-            "{}/{}",
-            cli.streams_endpoint(),
-            user_data.large_model_instance_id
-        ))?;
-        let req = GooseRequest::builder()
-            .method(GooseMethod::Get)
-            .set_request_builder(user.client.get(streams_url))
-            .expect_status_code(200)
-            .build();
-        let commits_url = user.build_url(cli.commits_endpoint())?;
-        (model, commits_url, req)
-    };
-    let mut goose = user.request(req).await?;
-    let resp: StreamsResponseOrError = goose.response?.json().await?;
-    let resp = goose_try!(user, "update", &mut goose.request, {
-        resp.resolve("update_large_model_get")
-    })?;
-
-    let req = {
-        let user_data: &LoadTestUserData = user.get_session_data_unchecked();
-        user_data
-            .cli
-            .create_replace_request(&model, &resp, &models::LargeModel::random())
-            .await
-            .unwrap()
-    };
-    let req = user.client.post(url).json(&req);
-    let req = GooseRequest::builder()
-        .method(GooseMethod::Post)
-        .set_request_builder(req)
-        .expect_status_code(200)
-        .build();
-    let mut goose = user.request(req).await?;
-    let resp: StreamsResponseOrError = goose.response?.json().await?;
-    goose_try!(
-        user,
-        "update",
-        &mut goose.request,
-        resp.resolve("update_large_model")
-    )?;
-    Ok(())
-}
-
-async fn get_large_model(user: &mut GooseUser) -> TransactionResult {
-    let user_data: &LoadTestUserData = user.get_session_data_unchecked();
-    let cli: &CeramicClient = &user_data.cli;
-    let url = user.build_url(&format!(
-        "{}/{}",
-        cli.streams_endpoint(),
-        user_data.large_model_instance_id
-    ))?;
-    let mut goose = user.get(&url).await?;
-    let resp: StreamsResponseOrError = goose.response?.json().await?;
-    goose_try!(
-        user,
-        "get",
-        &mut goose.request,
-        resp.resolve("get_large_instance")
-    )?;
-    Ok(())
 }

--- a/runner/src/scenario/ceramic/model_reuse.rs
+++ b/runner/src/scenario/ceramic/model_reuse.rs
@@ -53,8 +53,13 @@ pub(crate) async fn set_model_id(
 pub(crate) async fn get_model_id(conn: &mut redis::aio::Connection, key: &str) -> StreamId {
     loop {
         if conn.exists(key).await.unwrap() {
-            let id: String = conn.get(MODEL_ID_KEY).await.unwrap();
-            return StreamId::from_str(&id).unwrap();
+            let id: String = conn.get(key).await.unwrap();
+            return StreamId::from_str(&id)
+                .map_err(|e| {
+                    tracing::error!("invalid stream: {:?} ", e);
+                    e
+                })
+                .unwrap();
         } else {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }

--- a/runner/src/scenario/ceramic/model_reuse.rs
+++ b/runner/src/scenario/ceramic/model_reuse.rs
@@ -13,7 +13,7 @@ use std::{sync::Arc, time::Duration};
 use tracing::instrument;
 
 #[derive(Clone)]
-pub struct LoadTestUserData {
+struct ModelReuseLoadTestUserData {
     cli: CeramicHttpClient<JwkSigner>,
     redis_cli: redis::Client,
     model_id: StreamId,
@@ -78,7 +78,7 @@ async fn setup(
         get_model_id(&mut conn).await
     };
 
-    let user_data = LoadTestUserData {
+    let user_data = ModelReuseLoadTestUserData {
         cli,
         redis_cli,
         model_id,
@@ -90,8 +90,8 @@ async fn setup(
 }
 
 async fn create_instance(user: &mut GooseUser) -> TransactionResult {
-    let user_data: LoadTestUserData = {
-        let data: &LoadTestUserData = user.get_session_data_unchecked();
+    let user_data: ModelReuseLoadTestUserData = {
+        let data: &ModelReuseLoadTestUserData = user.get_session_data_unchecked();
         data.clone()
     };
     let cli = &user_data.cli;
@@ -131,7 +131,7 @@ async fn get_model_instance_id(conn: &mut redis::aio::Connection) -> StreamId {
 }
 
 async fn get_instance(user: &mut GooseUser) -> TransactionResult {
-    let user_data: &LoadTestUserData = user.get_session_data_unchecked();
+    let user_data: &ModelReuseLoadTestUserData = user.get_session_data_unchecked();
     let cli: &CeramicClient = &user_data.cli;
     let mut redis_conn = user_data.redis_cli.get_async_connection().await.unwrap();
     let model_instance_id = get_model_instance_id(&mut redis_conn).await;

--- a/runner/src/scenario/ceramic/model_reuse.rs
+++ b/runner/src/scenario/ceramic/model_reuse.rs
@@ -37,8 +37,6 @@ pub async fn scenario() -> Result<Scenario, GooseError> {
     let get_instance_tx = transaction!(get_instance).set_name("get_instance");
 
     Ok(scenario!("CeramicModelReuseScenario")
-        // After each transactions runs, sleep randomly from 1 to 5 seconds.
-        .set_wait_time(Duration::from_secs(1), Duration::from_secs(5))?
         .register_transaction(test_start)
         .register_transaction(create_instance_tx)
         .register_transaction(get_instance_tx))

--- a/runner/src/scenario/ceramic/new_streams.rs
+++ b/runner/src/scenario/ceramic/new_streams.rs
@@ -1,7 +1,7 @@
 use crate::goose_try;
 use ceramic_http_client::CeramicHttpClient;
 use goose::prelude::*;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use crate::scenario::ceramic::util::goose_error;
 use crate::scenario::ceramic::{
@@ -27,7 +27,6 @@ pub async fn scenario() -> Result<Scenario, GooseError> {
         transaction!(instantiate_large_model).set_name("instantiate_large_model");
 
     Ok(scenario!("CeramicNewStreams")
-        .set_wait_time(Duration::from_millis(10), Duration::from_millis(100))?
         .register_transaction(test_start)
         .register_transaction(instantiate_small_model)
         .register_transaction(instantiate_large_model))

--- a/runner/src/scenario/ceramic/new_streams.rs
+++ b/runner/src/scenario/ceramic/new_streams.rs
@@ -5,7 +5,9 @@ use std::{sync::Arc, time::Duration};
 
 use crate::scenario::ceramic::util::goose_error;
 use crate::scenario::ceramic::{
-    models, setup, Credentials, LoadTestUserData, RandomModelInstance, StreamsResponseOrError,
+    models,
+    simple::{setup, LoadTestUserData},
+    Credentials, RandomModelInstance, StreamsResponseOrError,
 };
 
 pub async fn scenario() -> Result<Scenario, GooseError> {

--- a/runner/src/scenario/ceramic/query.rs
+++ b/runner/src/scenario/ceramic/query.rs
@@ -53,11 +53,9 @@ pub async fn scenario() -> Result<Scenario, GooseError> {
     let creds = Credentials::from_env().await.map_err(goose_error)?;
     let cli = CeramicHttpClient::new(creds.signer);
 
-    let test_start = Transaction::new(Arc::new(move |user| {
-        Box::pin(setup(user, cli.clone()))
-    }))
-    .set_name("setup")
-    .set_on_start();
+    let test_start = Transaction::new(Arc::new(move |user| Box::pin(setup(user, cli.clone()))))
+        .set_name("setup")
+        .set_on_start();
 
     let pre_query_models =
         transaction!(query_models_pre_update).set_name("pre_update_query_models");

--- a/runner/src/scenario/ceramic/query.rs
+++ b/runner/src/scenario/ceramic/query.rs
@@ -9,7 +9,7 @@ use ceramic_http_client::{
 };
 use goose::prelude::*;
 use std::collections::HashMap;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 use tracing::instrument;
 
 #[derive(Clone)]
@@ -64,8 +64,6 @@ pub async fn scenario() -> Result<Scenario, GooseError> {
         transaction!(query_models_post_update).set_name("post_update_query_models");
 
     Ok(scenario!("CeramicQueryScenario")
-        // After each transactions runs, sleep randomly from 1 to 5 seconds.
-        .set_wait_time(Duration::from_secs(1), Duration::from_secs(5))?
         .register_transaction(test_start)
         .register_transaction(pre_query_models)
         .register_transaction(update_models)

--- a/runner/src/scenario/ceramic/simple.rs
+++ b/runner/src/scenario/ceramic/simple.rs
@@ -9,7 +9,7 @@ use ceramic_http_client::ceramic_event::StreamId;
 use ceramic_http_client::CeramicHttpClient;
 use ceramic_http_client::{ModelAccountRelation, ModelDefinition};
 use goose::prelude::*;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 use tracing::instrument;
 
 pub(crate) struct LoadTestUserData {
@@ -72,8 +72,6 @@ pub async fn scenario() -> Result<Scenario, GooseError> {
     let get_large_model = transaction!(get_large_model).set_name("get_large_model");
 
     Ok(scenario!("CeramicSimpleScenario")
-        // After each transactions runs, sleep randomly from 1 to 5 seconds.
-        .set_wait_time(Duration::from_secs(1), Duration::from_secs(5))?
         .register_transaction(test_start)
         .register_transaction(update_small_model)
         .register_transaction(get_small_model)

--- a/runner/src/scenario/ceramic/simple.rs
+++ b/runner/src/scenario/ceramic/simple.rs
@@ -1,0 +1,219 @@
+use super::{models::RandomModelInstance, CeramicClient, Credentials};
+
+use crate::goose_try;
+use crate::scenario::ceramic::models;
+use crate::scenario::ceramic::util::{goose_error, setup_model, setup_model_instance};
+
+use ceramic_http_client::api::StreamsResponseOrError;
+use ceramic_http_client::ceramic_event::StreamId;
+use ceramic_http_client::CeramicHttpClient;
+use ceramic_http_client::{ModelAccountRelation, ModelDefinition};
+use goose::prelude::*;
+use std::{sync::Arc, time::Duration};
+use tracing::instrument;
+
+pub(crate) struct LoadTestUserData {
+    pub cli: CeramicClient,
+    pub small_model_id: StreamId,
+    pub small_model_instance_id: StreamId,
+    pub large_model_id: StreamId,
+    pub large_model_instance_id: StreamId,
+}
+
+#[instrument(skip_all, fields(user.index = user.weighted_users_index), ret)]
+pub(crate) async fn setup(user: &mut GooseUser, cli: CeramicClient) -> TransactionResult {
+    let small_model = ModelDefinition::new::<models::SmallModel>(
+        "load_test_small_model",
+        ModelAccountRelation::List,
+    )
+    .unwrap();
+    let small_model_id = setup_model(user, &cli, small_model).await?;
+    let small_model_instance_id =
+        setup_model_instance(user, &cli, &small_model_id, &models::SmallModel::random()).await?;
+    let large_model = ModelDefinition::new::<models::LargeModel>(
+        "load_test_large_model",
+        ModelAccountRelation::List,
+    )
+    .unwrap();
+    let large_model_id = setup_model(user, &cli, large_model).await?;
+    let large_model_instance_id =
+        setup_model_instance(user, &cli, &large_model_id, &models::LargeModel::random()).await?;
+
+    let user_data = LoadTestUserData {
+        cli,
+        small_model_id,
+        small_model_instance_id,
+        large_model_id,
+        large_model_instance_id,
+    };
+
+    user.set_session_data(user_data);
+
+    Ok(())
+}
+
+pub async fn scenario() -> Result<Scenario, GooseError> {
+    let creds = Credentials::from_env().await.map_err(goose_error)?;
+    let cli = CeramicHttpClient::new(creds.signer);
+
+    let setup_cli = cli;
+    let test_start = Transaction::new(Arc::new(move |user| {
+        Box::pin(setup(user, setup_cli.clone()))
+    }))
+    .set_name("setup")
+    .set_on_start();
+
+    let update_small_model = transaction!(update_small_model).set_name("update_small_model");
+
+    let get_small_model = transaction!(get_small_model).set_name("get_small_model");
+
+    let update_large_model = transaction!(update_large_model).set_name("update_large_model");
+
+    let get_large_model = transaction!(get_large_model).set_name("get_large_model");
+
+    Ok(scenario!("CeramicSimpleScenario")
+        // After each transactions runs, sleep randomly from 1 to 5 seconds.
+        .set_wait_time(Duration::from_secs(1), Duration::from_secs(5))?
+        .register_transaction(test_start)
+        .register_transaction(update_small_model)
+        .register_transaction(get_small_model)
+        .register_transaction(update_large_model)
+        .register_transaction(get_large_model))
+}
+
+pub(crate) async fn update_small_model(user: &mut GooseUser) -> TransactionResult {
+    let (model, url, req) = {
+        let user_data: &LoadTestUserData = user.get_session_data_unchecked();
+        let model = user_data.small_model_id.clone();
+        let cli = &user_data.cli;
+        let streams_url = user.build_url(&format!(
+            "{}/{}",
+            cli.streams_endpoint(),
+            user_data.small_model_instance_id
+        ))?;
+        let req = GooseRequest::builder()
+            .method(GooseMethod::Get)
+            .set_request_builder(user.client.get(streams_url))
+            .expect_status_code(200)
+            .build();
+        let commits_url = user.build_url(cli.commits_endpoint())?;
+        (model, commits_url, req)
+    };
+    let resp = user.request(req).await?;
+    let resp: StreamsResponseOrError = resp.response?.json().await?;
+    let resp = resp.resolve("update_small_model_get").unwrap();
+
+    let req = {
+        let user_data: &LoadTestUserData = user.get_session_data_unchecked();
+        user_data
+            .cli
+            .create_replace_request(&model, &resp, &models::SmallModel::random())
+            .await
+            .unwrap()
+    };
+    let req = user.client.post(url).json(&req);
+    let mut goose = user
+        .request(
+            GooseRequest::builder()
+                .method(GooseMethod::Post)
+                .set_request_builder(req)
+                .expect_status_code(200)
+                .build(),
+        )
+        .await?;
+    let resp: StreamsResponseOrError = goose.response?.json().await?;
+    goose_try!(
+        user,
+        "update",
+        &mut goose.request,
+        resp.resolve("update_small_model")
+    )?;
+    Ok(())
+}
+
+pub(crate) async fn get_small_model(user: &mut GooseUser) -> TransactionResult {
+    let user_data: &LoadTestUserData = user.get_session_data_unchecked();
+    let cli: &CeramicClient = &user_data.cli;
+    let url = user.build_url(&format!(
+        "{}/{}",
+        cli.streams_endpoint(),
+        user_data.small_model_instance_id
+    ))?;
+    let mut goose = user.get(&url).await?;
+    let resp: StreamsResponseOrError = goose.response?.json().await?;
+    goose_try!(
+        user,
+        "get",
+        &mut goose.request,
+        resp.resolve("get_small_instance")
+    )?;
+    Ok(())
+}
+
+pub(crate) async fn update_large_model(user: &mut GooseUser) -> TransactionResult {
+    let (model, url, req) = {
+        let user_data: &LoadTestUserData = user.get_session_data_unchecked();
+        let model = user_data.large_model_id.clone();
+        let cli = &user_data.cli;
+        let streams_url = user.build_url(&format!(
+            "{}/{}",
+            cli.streams_endpoint(),
+            user_data.large_model_instance_id
+        ))?;
+        let req = GooseRequest::builder()
+            .method(GooseMethod::Get)
+            .set_request_builder(user.client.get(streams_url))
+            .expect_status_code(200)
+            .build();
+        let commits_url = user.build_url(cli.commits_endpoint())?;
+        (model, commits_url, req)
+    };
+    let mut goose = user.request(req).await?;
+    let resp: StreamsResponseOrError = goose.response?.json().await?;
+    let resp = goose_try!(user, "update", &mut goose.request, {
+        resp.resolve("update_large_model_get")
+    })?;
+
+    let req = {
+        let user_data: &LoadTestUserData = user.get_session_data_unchecked();
+        user_data
+            .cli
+            .create_replace_request(&model, &resp, &models::LargeModel::random())
+            .await
+            .unwrap()
+    };
+    let req = user.client.post(url).json(&req);
+    let req = GooseRequest::builder()
+        .method(GooseMethod::Post)
+        .set_request_builder(req)
+        .expect_status_code(200)
+        .build();
+    let mut goose = user.request(req).await?;
+    let resp: StreamsResponseOrError = goose.response?.json().await?;
+    goose_try!(
+        user,
+        "update",
+        &mut goose.request,
+        resp.resolve("update_large_model")
+    )?;
+    Ok(())
+}
+
+pub(crate) async fn get_large_model(user: &mut GooseUser) -> TransactionResult {
+    let user_data: &LoadTestUserData = user.get_session_data_unchecked();
+    let cli: &CeramicClient = &user_data.cli;
+    let url = user.build_url(&format!(
+        "{}/{}",
+        cli.streams_endpoint(),
+        user_data.large_model_instance_id
+    ))?;
+    let mut goose = user.get(&url).await?;
+    let resp: StreamsResponseOrError = goose.response?.json().await?;
+    goose_try!(
+        user,
+        "get",
+        &mut goose.request,
+        resp.resolve("get_large_instance")
+    )?;
+    Ok(())
+}

--- a/runner/src/scenario/ceramic/write_only.rs
+++ b/runner/src/scenario/ceramic/write_only.rs
@@ -1,6 +1,6 @@
 use ceramic_http_client::CeramicHttpClient;
 use goose::prelude::*;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use crate::scenario::ceramic::simple::{setup, update_large_model, update_small_model};
 use crate::scenario::ceramic::util::goose_error;
@@ -23,7 +23,6 @@ pub async fn scenario() -> Result<Scenario, GooseError> {
     let update_large_model = transaction!(update_large_model).set_name("update_large_model");
 
     Ok(scenario!("CeramicWriteOnly")
-        .set_wait_time(Duration::from_millis(9000), Duration::from_millis(11000))?
         .register_transaction(setup)
         .register_transaction(update_small_model)
         .register_transaction(update_large_model))

--- a/runner/src/scenario/ceramic/write_only.rs
+++ b/runner/src/scenario/ceramic/write_only.rs
@@ -2,8 +2,10 @@ use ceramic_http_client::CeramicHttpClient;
 use goose::prelude::*;
 use std::{sync::Arc, time::Duration};
 
+use crate::scenario::ceramic::simple::{setup, update_large_model, update_small_model};
 use crate::scenario::ceramic::util::goose_error;
-use crate::scenario::ceramic::{setup, update_large_model, update_small_model, Credentials};
+
+use super::Credentials;
 
 pub async fn scenario() -> Result<Scenario, GooseError> {
     let creds = Credentials::from_env().await.map_err(goose_error)?;

--- a/runner/src/scenario/ipfs_block_fetch.rs
+++ b/runner/src/scenario/ipfs_block_fetch.rs
@@ -27,8 +27,6 @@ pub fn scenario(topo: Topology) -> Result<Scenario> {
     .set_on_stop();
 
     Ok(scenario!("IpfsRpc")
-        // After each transactions runs, sleep randomly from 1 to 5 seconds.
-        .set_wait_time(Duration::from_secs(1), Duration::from_secs(5))?
         // This transaction only runs one time when the user first starts.
         .register_transaction(put)
         // These next two transactions run repeatedly as long as the load test is running.

--- a/runner/src/scenario/ipfs_block_fetch.rs
+++ b/runner/src/scenario/ipfs_block_fetch.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use cid::Cid;
+use ceramic_core::Cid;
 use goose::prelude::*;
 use libipld::prelude::Codec;
 use libipld::{ipld, json::DagJsonCodec};

--- a/runner/src/simulate.rs
+++ b/runner/src/simulate.rs
@@ -753,7 +753,7 @@ mod test {
     use std::collections::HashMap;
 
     use keramik_common::peer_info::CeramicPeerInfo;
-    use tracing_test::traced_test;
+    use test_log::test;
 
     use super::*;
 
@@ -849,8 +849,7 @@ mod test {
             .await
     }
 
-    #[traced_test]
-    #[tokio::test]
+    #[test(tokio::test)]
     async fn event_id_sync_verify_metrics_exact_default() {
         let run_time = 60;
         let threshold = 300;
@@ -873,8 +872,7 @@ mod test {
         }
     }
 
-    #[traced_test]
-    #[tokio::test]
+    #[test(tokio::test)]
     async fn event_id_sync_verify_metrics_overridden_target() {
         let run_time = 60;
         let threshold = 55;
@@ -897,8 +895,7 @@ mod test {
         }
     }
 
-    #[traced_test]
-    #[tokio::test]
+    #[test(tokio::test)]
     async fn event_id_sync_verify_metrics_overridden_target_too_low() {
         let run_time = 60;
         let threshold = 45;
@@ -923,8 +920,7 @@ mod test {
         }
     }
 
-    #[traced_test]
-    #[tokio::test]
+    #[test(tokio::test)]
     async fn event_id_sync_verify_metrics_too_low() {
         let run_time = 60;
         let threshold = 300;
@@ -949,8 +945,7 @@ mod test {
         }
     }
 
-    #[traced_test]
-    #[tokio::test]
+    #[test(tokio::test)]
     async fn event_id_sync_verify_metrics_too_low_ok_workers() {
         let run_time = 60;
         let threshold = 300;
@@ -973,8 +968,7 @@ mod test {
         }
     }
 
-    #[traced_test]
-    #[tokio::test]
+    #[test(tokio::test)]
     async fn event_id_sync_verify_metrics_too_low_second_run() {
         let run_time = 60;
         let threshold = 300;

--- a/runner/src/simulate.rs
+++ b/runner/src/simulate.rs
@@ -349,7 +349,7 @@ impl ScenarioState {
                 };
 
                 // For now, assume writer and all peers must meet the threshold rate
-                let mut errors = peer_req_cnts.into_iter().zip(before_metrics.into_iter())
+                let mut errors = peer_req_cnts.into_iter().zip(before_metrics.iter())
                     .enumerate()
                     .flat_map(|(idx, (current, before))| {
                         if let Some(c) = current {

--- a/runner/src/simulate.rs
+++ b/runner/src/simulate.rs
@@ -129,7 +129,7 @@ pub async fn simulate(opts: Opts) -> Result<()> {
 
     let scenario = match opts.scenario {
         Scenario::IpfsRpc => ipfs_block_fetch::scenario(topo)?,
-        Scenario::CeramicSimple => ceramic::scenario().await?,
+        Scenario::CeramicSimple => ceramic::simple::scenario().await?,
         Scenario::CeramicWriteOnly => ceramic::write_only::scenario().await?,
         Scenario::CeramicNewStreams => ceramic::new_streams::scenario().await?,
         Scenario::CeramicQuery => ceramic::query::scenario().await?,


### PR DESCRIPTION
Linear ticket WS1-1409.

This PR includes #127 and pulls those changes into main, as well as some refactoring, and the implementation of two new scenarios called `recon-event-key-sync` and `recon-event-sync`. These scenarios include a step to inspect the goose metrics, as well as metrics from other peers to verify that the scenario passed. It will return a non-zero exit code if fails. This looks different to the manager process than an execution error, however, I'm not sure what needs to be done to prevent the manager from restarting in this case. As soon as it completes with the error, a new job starts but it won't actually start a new simulation (I hope/think this is okay).

The simulation spec includes a new field `success_request_target` that will control the threshold used to verify the scenario passed. Here is my thinking about how it should work from the field docs: `Request target for the scenario to be a success. Scenarios can use this to validate throughput and correctness before returning. The exact definition is left to the scenario (requests per second, total requests, rps/node etc).`

I imported rust-ceramic core to generate Event IDs and had to adjust some multiformat versions. I tried to avoid updating things or making too many changes, but the newest version of multihash refactors things substantially. It isn't backward compatible and hasn't been pulled into ipld-dag-cbor yet, but is in new multiaddr and CID crates, so we use public exports and a shared version when appropriate.

---- 
**New Scenario**

This adds two new runner scenarios for Recon. They both follow a similar flow, however, one sends `{eventId: "key", eventData: "payload"}` while the other just sends event IDs.  The flow is as follows, by default it targets 300 req/second, and can be overridden by the `sucessRequestTarget` scenario spec field. This target is verified as number of new events created on every peer using the `recon_key_insert_count_total` counter.

This scenario is a bit odd in that it mostly talks to the IPFS endpoint for recon, but also needs the ceramic API for model creation. We also constrain which node and how many users take certain actions in a way we historically haven't.

**Setup** (once):

- One user on one worker creates a model. It publishes the model ID to redis for other nodes.
  - Goose doesn't provide APIs to communicate from manager/workers currently, so we use redis. There is a socket that workers connect and report to the manager so we could implement it but redis is easy enough. Currently, workers are assigned a unique ID (int) when connecting to the manager, which we use to ensure that only 1 worker creates a model and creates events.
- One user on every workers will subscribe to updates for this model (after reading it out of redis).

**Key sync** (every time):
- One worker will create a random new event ID and store it. This triggers recon sync. We have all the users on the worker doing this, in order to create as much load as we desire
- The other workers no-op.

```yaml
apiVersion: "keramik.3box.io/v1alpha1"
kind: Simulation
metadata:
  name: recon
  # Must be the same namespace as the network to test
  namespace: keramik-small
spec:
  scenario: recon-event-sync # or recon-event-key-sync if you're using rust-ceramic without recon data
  throttleRequests: 280 # include to define a "steady sync" scenario where the worker creates about this many events/second
  successRequestTarget: 10 # override the default value of 300 to determine how many events must be synced per second to other peers in the network
  users: 8 # increase to generate more events, 1 is probably sufficient for our 300/s goal
  runTime: 10
  ```