### PR TITLE
feat: implement `devMode` setting to override all container resource requests/limits

### DIFF
--- a/keramik/src/advanced_configuration.md
+++ b/keramik/src/advanced_configuration.md
@@ -70,7 +70,25 @@ and adding the following environment variables to the `spec/template/spec/contai
 
 # Image Resources
 
-You can also use the [network](./setup_network.md) specification to specify resources for the pods that are running
+During local benchmarking, you may not have enough resources to run the cluster. A simple "fix" is to use the `devMode` flag on the network and simulation specs. This will override the resource requests and limits values to be none, which means it doesn't need available resources to deploy, and can consume as much as it desires. This would be problematic in production and should only be used for testing purposes.
+
+```yaml
+# network configuration
+---
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: small
+spec:
+  replicas: 2
+  devMode: true # ceramic will require specified resources but all other containers will be unconstrained
+  ceramic:
+    - resourceLimits:
+        cpu: "1"
+        memory: "1Gi"
+        storage: "1Gi"
+```
+
 
 ```yaml
 # network configuration

--- a/keramik/src/simulation.md
+++ b/keramik/src/simulation.md
@@ -23,6 +23,7 @@ metadata:
   namespace: keramik-<unique-name>-small
 spec:
   scenario: ceramic-simple
+  devMode: true # optional to remove container resource limits and requirements for local benchmarking
   users: 10
   runTime: 4
 ```

--- a/operator/src/monitoring/opentelemetry.rs
+++ b/operator/src/monitoring/opentelemetry.rs
@@ -17,7 +17,7 @@ use k8s_openapi::{
     },
 };
 
-use crate::labels::selector_labels;
+use crate::{labels::selector_labels, network::resource_limits::ResourceLimitsConfig};
 
 use crate::simulation::controller::{OTEL_ACCOUNT, OTEL_CONFIG_MAP_NAME, OTEL_CR};
 
@@ -54,7 +54,31 @@ pub fn service_spec() -> ServiceSpec {
     }
 }
 
-pub fn stateful_set_spec() -> StatefulSetSpec {
+fn resource_requirements(dev_mode: bool) -> ResourceRequirements {
+    if dev_mode {
+        ResourceRequirements {
+            limits: Some(ResourceLimitsConfig::dev_default().into()),
+            requests: Some(ResourceLimitsConfig::dev_default().into()),
+            ..Default::default()
+        }
+    } else {
+        ResourceRequirements {
+            limits: Some(BTreeMap::from_iter(vec![
+                ("cpu".to_owned(), Quantity("250m".to_owned())),
+                ("ephemeral-storage".to_owned(), Quantity("1Gi".to_owned())),
+                ("memory".to_owned(), Quantity("1Gi".to_owned())),
+            ])),
+            requests: Some(BTreeMap::from_iter(vec![
+                ("cpu".to_owned(), Quantity("250m".to_owned())),
+                ("ephemeral-storage".to_owned(), Quantity("1Gi".to_owned())),
+                ("memory".to_owned(), Quantity("1Gi".to_owned())),
+            ])),
+            ..Default::default()
+        }
+    }
+}
+
+pub fn stateful_set_spec(dev_mode: bool) -> StatefulSetSpec {
     StatefulSetSpec {
         replicas: Some(1),
         service_name: OTEL_APP.to_owned(),
@@ -98,19 +122,7 @@ pub fn stateful_set_spec() -> StatefulSetSpec {
                             ..Default::default()
                         },
                     ]),
-                    resources: Some(ResourceRequirements {
-                        limits: Some(BTreeMap::from_iter(vec![
-                            ("cpu".to_owned(), Quantity("250m".to_owned())),
-                            ("ephemeral-storage".to_owned(), Quantity("1Gi".to_owned())),
-                            ("memory".to_owned(), Quantity("1Gi".to_owned())),
-                        ])),
-                        requests: Some(BTreeMap::from_iter(vec![
-                            ("cpu".to_owned(), Quantity("250m".to_owned())),
-                            ("ephemeral-storage".to_owned(), Quantity("1Gi".to_owned())),
-                            ("memory".to_owned(), Quantity("1Gi".to_owned())),
-                        ])),
-                        ..Default::default()
-                    }),
+                    resources: Some(resource_requirements(dev_mode)),
                     volume_mounts: Some(vec![
                         VolumeMount {
                             mount_path: "/config".to_owned(),

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -46,6 +46,10 @@ pub struct NetworkSpec {
     /// The number of seconds this network should live.
     /// If unset the network lives forever.
     pub ttl_seconds: Option<u64>,
+    /// Enable dev mode for the network. This will remove resource requests/limits that are not
+    /// explicitly overridden by the spec. This allows deploying the network on a smaller machine,
+    /// as well as running every container with unlimited resources.
+    pub dev_mode: Option<bool>,
 }
 
 /// Local network ID.

--- a/operator/src/simulation/controller.rs
+++ b/operator/src/simulation/controller.rs
@@ -371,7 +371,7 @@ async fn apply_redis(
         ns,
         orefs.clone(),
         "redis",
-        redis::stateful_set_spec(),
+        redis::stateful_set_spec(simulation.dev_mode()),
     )
     .await?;
 
@@ -402,7 +402,7 @@ async fn apply_jaeger(
         ns,
         orefs.clone(),
         "jaeger",
-        jaeger::stateful_set_spec(),
+        jaeger::stateful_set_spec(simulation.dev_mode()),
     )
     .await?;
     Ok(())
@@ -431,7 +431,7 @@ async fn apply_prometheus(
         ns,
         orefs.clone(),
         "prometheus",
-        prometheus::stateful_set_spec(),
+        prometheus::stateful_set_spec(simulation.dev_mode()),
     )
     .await?;
     Ok(())
@@ -484,7 +484,7 @@ async fn apply_opentelemetry(
         ns,
         orefs.clone(),
         "opentelemetry",
-        opentelemetry::stateful_set_spec(),
+        opentelemetry::stateful_set_spec(simulation.dev_mode()),
     )
     .await?;
 

--- a/operator/src/simulation/redis.rs
+++ b/operator/src/simulation/redis.rs
@@ -14,7 +14,10 @@ use k8s_openapi::{
     },
 };
 
-use crate::labels::{managed_labels, selector_labels};
+use crate::{
+    labels::{managed_labels, selector_labels},
+    network::resource_limits::ResourceLimitsConfig,
+};
 
 pub const REDIS_APP: &str = "redis";
 
@@ -33,7 +36,7 @@ pub fn service_spec() -> ServiceSpec {
     }
 }
 
-pub fn stateful_set_spec() -> StatefulSetSpec {
+pub fn stateful_set_spec(dev_mode: bool) -> StatefulSetSpec {
     StatefulSetSpec {
         replicas: Some(1),
         selector: LabelSelector {
@@ -60,24 +63,36 @@ pub fn stateful_set_spec() -> StatefulSetSpec {
                         ..Default::default()
                     }]),
                     env: None,
-                    resources: Some(ResourceRequirements {
-                        limits: Some(BTreeMap::from_iter(vec![
-                            ("cpu".to_owned(), Quantity("250m".to_owned())),
-                            ("ephemeral-storage".to_owned(), Quantity("1Gi".to_owned())),
-                            ("memory".to_owned(), Quantity("1Gi".to_owned())),
-                        ])),
-                        requests: Some(BTreeMap::from_iter(vec![
-                            ("cpu".to_owned(), Quantity("250m".to_owned())),
-                            ("ephemeral-storage".to_owned(), Quantity("1Gi".to_owned())),
-                            ("memory".to_owned(), Quantity("1Gi".to_owned())),
-                        ])),
-                        ..Default::default()
-                    }),
+                    resources: Some(resource_requirements(dev_mode)),
                     ..Default::default()
                 }],
                 ..Default::default()
             }),
         },
         ..Default::default()
+    }
+}
+
+fn resource_requirements(dev_mode: bool) -> ResourceRequirements {
+    if dev_mode {
+        ResourceRequirements {
+            limits: Some(ResourceLimitsConfig::dev_default().into()),
+            requests: Some(ResourceLimitsConfig::dev_default().into()),
+            ..Default::default()
+        }
+    } else {
+        ResourceRequirements {
+            limits: Some(BTreeMap::from_iter(vec![
+                ("cpu".to_owned(), Quantity("250m".to_owned())),
+                ("ephemeral-storage".to_owned(), Quantity("1Gi".to_owned())),
+                ("memory".to_owned(), Quantity("1Gi".to_owned())),
+            ])),
+            requests: Some(BTreeMap::from_iter(vec![
+                ("cpu".to_owned(), Quantity("250m".to_owned())),
+                ("ephemeral-storage".to_owned(), Quantity("1Gi".to_owned())),
+                ("memory".to_owned(), Quantity("1Gi".to_owned())),
+            ])),
+            ..Default::default()
+        }
     }
 }

--- a/operator/src/simulation/spec.rs
+++ b/operator/src/simulation/spec.rs
@@ -31,6 +31,17 @@ pub struct SimulationSpec {
     /// validate throughput and correctness before returning. The exact definition is
     /// left to the scenario (requests per second, total requests, rps/node etc).
     pub success_request_target: Option<usize>,
+    /// Enable dev mode for the simulation. This will remove resource limits that are not
+    /// explicitly set in the simulation spec.
+    pub(crate) dev_mode: Option<bool>,
+}
+
+impl Simulation {
+    /// Whether the simulation is in dev mode, meaning resource limits are not applied unless specified.
+    /// May have other implications in the future.
+    pub fn dev_mode(&self) -> bool {
+        self.spec.dev_mode.unwrap_or(false)
+    }
 }
 
 /// Current status of a simulation.


### PR DESCRIPTION
I added a `devMode` boolean to the network and simulation specs, which will set all container resource requests/limits to None for CPU/RAM, unless explicitly included in the spec. Storage remains specified as a missing value is an error (it's possible I just missed the way around this, but it seems okay as it's not the issue). The network and simulation values are independent, network applies to those containers (e.g. CAS, IPFS) while the simulation applies to redis and the monitoring containers. 

I implemented it using a global variable for the network side, which is ugly. It applies to the entire system, and could mean other things in the future so it doesn't seem totally wrong, but it does seem wrong. I considered passing the spec down, or adding a new bool parameter but it will require some refactoring. I'm willing to tackle it if deemed important now.  I considered sharing the function across every container but we may want to hard code different defaults in the future, so I left them separate as that's how they were previously defined, even though they share values in most cases.

I've been this in my local testing and it's helpful for running things on macbooks with less available RAM, of if you just want to let everything go bananas and see what uses the most resources.