### PR TITLE
feat: add scripts to help spin up local cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ target/
 .env*
 /book
 *.idea
+__pycache__
+
+# allow a sample network in the repo
+!local-scripts/small.yaml

--- a/local-scripts/load.py
+++ b/local-scripts/load.py
@@ -1,0 +1,45 @@
+import subprocess
+
+images = [
+        'amazon/aws-cli',
+        'ceramicnetwork/ceramic-anchor-service:latest',
+        'ceramicnetwork/composedb:latest',
+        'gresau/localstack-persist:2',
+        'public.ecr.aws/r5b3e0r5/3box/cas-contract',
+        'public.ecr.aws/r5b3e0r5/3box/ceramic-one',
+        'public.ecr.aws/r5b3e0r5/3box/go-cas:latest',
+        'trufflesuite/ganache'
+        ]
+
+
+def run_command_for_images(command: list):
+    results = []
+    for image in images:
+        exec = command.copy()
+        exec.append(image)
+        process = subprocess.Popen(exec, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        results.append(process)
+    return results
+
+
+def check_results(results): 
+    for process in results:
+        stdout, stderr = process.communicate()
+        if process.returncode != 0:
+            print("Error: %s" % stderr.decode())
+
+
+def pull_and_load_images() -> None:
+    print("Attempting to load local rust-ceramic, operator and runner images")
+    subprocess.run(["kind", "load", "docker-image", "keramik/operator:dev"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subprocess.run(["kind", "load", "docker-image", "keramik/runner:dev"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subprocess.run(["kind", "load", "docker-image", "3box/ceramic-one:latest"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    print("Attempting to pull and load other images")
+    res = run_command_for_images(["docker", "pull"])
+    check_results(res)
+    res = run_command_for_images(["kind", "load", "docker-image"])
+    check_results(res)
+
+
+if __name__ == '__main__':
+    pull_and_load_images()

--- a/local-scripts/setup.sh
+++ b/local-scripts/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# USAGE: ./setup.sh [network.yaml]
+# If you don't specify a network, it will use the small.yaml network file in this folder.
+# This script will create a kind cluster, install the operator, and load the network into the cluster.
+# It will pull all the images to your machine, and then load them into the cluster. This can take a while,
+# but it makes subsequent restarts of the cluster much faster, as we don't need to redownload all the images,
+# we just need to load them in.
+
+NETWORK=$1
+if [ -z "$NETWORK" ]; then
+    NETWORK="./small.yaml"
+fi
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# cluster might already exist and that's okay
+kind create cluster --config "./kind.yaml" || true
+
+cargo run --bin crdgen --manifest-path "./../Cargo.toml" | kubectl apply -f -
+
+kubectl create namespace keramik || true # same for namespace. we don't care if it already exists
+kubectl apply -k "./../k8s/operator/"
+
+python3 ./load.py
+
+kubectl apply -f $NETWORK
+NETWORK_NAME=small
+echo export NETWORK_NAME=small
+kubectl describe network $NETWORK_NAME
+kubectl config set-context --current --namespace=keramik-$NETWORK_NAME
+

--- a/local-scripts/small.yaml
+++ b/local-scripts/small.yaml
@@ -1,0 +1,17 @@
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: small
+spec:
+  replicas: 2
+  bootstrap:
+    image: runner:dev
+    imagePullPolicy: IfNotPresent
+  cas:
+    ipfs:
+      go: {} 
+  ceramic:
+    - ipfs:
+        rust: {} 
+      env:
+        CERAMIC_PUBSUB_QPS_LIMIT: "1000"


### PR DESCRIPTION
I found myself nuking and re-creating my cluster _a lot_. Without a script like this, it takes forever to re-download all the images and get the cluster reconciled. This makes it much faster. You can just run `kind delete cluster && ./local-scripts/setup.sh "network.yaml"` and it will go through the steps of creating the cluster, applying the network and CRDs and then loading the images. 

It isn't one size fits all, but it does seem like a useful thing to include. If others disagree, I'm okay with closing this PR. I have a local version of .gitignore with my own folders commented with things like results, network and simulation definitions, and helper scripts. Also open to updating docs/readme etc to make the usage of these more obvious, but they're pretty straightforward scripts.