### PR TITLE
feat: add ability to disable local monitoring simulation resources

### DIFF
--- a/operator/src/simulation/spec.rs
+++ b/operator/src/simulation/spec.rs
@@ -31,6 +31,24 @@ pub struct SimulationSpec {
     /// validate throughput and correctness before returning. The exact definition is
     /// left to the scenario (requests per second, total requests, rps/node etc).
     pub success_request_target: Option<usize>,
+    /// Monitoring resources for a simulation
+    pub monitoring: Option<MonitoringSpec>,
+
+}
+/// MonitoringSpec defines how Simulation will be monitored.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MonitoringSpec {
+    /// Monitoring in the namespace
+    pub local: Option<LocalMonitoringSpec>,
+}
+
+/// LocalMonitoringSpec defines monitoring in the namespace.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalMonitoringSpec {
+    /// Deploy monitoring to the namespace
+    pub enabled: bool,
 }
 
 /// Current status of a simulation.


### PR DESCRIPTION
For the case when a keramik network is externally monitored, like on cloud infra, we should not deploy simulation monitoring resources to the namespace.

We should also allow the configuring of additional monitoring configuration through the `.spec.monitoring` path.

Works fine on my local tests, but how do I default it to true?