### PR TITLE
feat: expose prometheus metrics from operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787"
 dependencies = [
  "futures-core",
  "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost-types",
  "tonic 0.10.2",
  "tracing-core",
 ]
@@ -971,7 +971,7 @@ dependencies = [
  "futures-task",
  "hdrhistogram",
  "humantime",
- "prost-types 0.12.3",
+ "prost-types",
  "serde",
  "serde_json",
  "thread_local",
@@ -1314,19 +1314,6 @@ dependencies = [
  "darling_core 0.20.3",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.3",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -1799,12 +1786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,6 +2037,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-timers"
@@ -2883,10 +2870,15 @@ dependencies = [
  "anyhow",
  "console-subscriber",
  "gethostname",
+ "hyper",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry-prometheus",
+ "opentelemetry_sdk",
+ "prometheus",
  "schemars",
  "serde",
+ "tokio",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -3683,12 +3675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3929,77 +3915,88 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.18.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c928609d087790fc936a1067bdc310ae702bdf3b090c3f281b713622c8bbde"
-dependencies = [
- "async-trait",
- "futures",
- "futures-util",
- "http",
- "opentelemetry",
- "opentelemetry-proto",
- "prost 0.11.9",
- "thiserror",
- "tokio",
- "tonic 0.8.3",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61a2f56df5574508dd86aaca016c917489e589ece4141df1b5e349af8d66c28"
-dependencies = [
- "futures",
- "futures-util",
- "opentelemetry",
- "prost 0.11.9",
- "tonic 0.8.3",
- "tonic-build",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
-dependencies = [
- "fnv",
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
+ "futures-core",
+ "futures-sink",
+ "indexmap 2.1.0",
  "js-sys",
  "once_cell",
  "pin-project-lite",
  "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost 0.11.9",
+ "thiserror",
+ "tokio",
+ "tonic 0.9.2",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8f082da115b0dcb250829e3ed0b8792b8f963a1ad42466e48422fbe6a079bd"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.11.9",
+ "tonic 0.9.2",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
+dependencies = [
+ "opentelemetry",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.18.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
- "dashmap",
- "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "once_cell",
- "opentelemetry_api",
+ "opentelemetry",
+ "ordered-float 4.2.0",
  "percent-encoding",
  "rand",
  "thiserror",
@@ -4015,6 +4012,15 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4162,16 +4168,6 @@ dependencies = [
  "once_cell",
  "pest",
  "sha2 0.10.8",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
-dependencies = [
- "fixedbitset",
- "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -4360,16 +4356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4432,6 +4418,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4449,28 +4450,6 @@ checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
  "prost-derive 0.12.3",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
-dependencies = [
- "bytes",
- "heck",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
 ]
 
 [[package]]
@@ -4501,21 +4480,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
-dependencies = [
- "prost 0.11.9",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
  "prost 0.12.3",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psl-types"
@@ -5045,7 +5021,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.1",
  "serde",
 ]
 
@@ -6120,7 +6096,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c45d225a08ebccf0e0c7d46db4066ea8ab05b29d3750ecc1a04f1675978bf3c8"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.1",
  "serde",
 ]
 
@@ -6400,14 +6376,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.7",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6419,15 +6394,12 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.11.9",
- "prost-derive 0.11.9",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -6455,19 +6427,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6571,16 +6530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6604,16 +6553,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.18.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
+checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
 dependencies = [
+ "js-sys",
  "once_cell",
  "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.1.4",
+ "tracing-log 0.2.0",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -6970,22 +6923,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.30",
-]
 
 [[package]]
 name = "whoami"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,8 @@ keramik-common = { path = "./common/", default-features = false }
 multiaddr = "0.17"
 multibase = "0.9.1"
 multihash = "0.18"
-opentelemetry = { version = "0.18", features = [
-    "metrics",
-    "trace",
-    "rt-tokio",
-] }
-opentelemetry-otlp = { version = "0.11", features = [
+opentelemetry = { version = "0.21", features = ["metrics", "trace"] }
+opentelemetry-otlp = { version = "0.14", features = [
     "metrics",
     "trace",
     "tokio",
@@ -32,7 +28,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["full", "tracing"] }
 tonic = { version = "0.8" }
 tracing = "0.1.37"
-tracing-opentelemetry = "0.18"
+tracing-opentelemetry = "0.22"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tracing-log = "0.1.3"
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,11 +7,16 @@ edition = "2021"
 [features]
 default = []
 telemetry = [
+    "dep:hyper",
     "dep:opentelemetry",
     "dep:opentelemetry-otlp",
+    "dep:opentelemetry-prometheus",
+    "dep:opentelemetry_sdk",
+    "dep:prometheus",
+    "dep:tokio",
+    "dep:tracing",
     "dep:tracing-opentelemetry",
     "dep:tracing-subscriber",
-    "dep:tracing",
 ]
 tokio-console = ["telemetry", "dep:console-subscriber"]
 
@@ -26,3 +31,13 @@ serde.workspace = true
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
+opentelemetry-prometheus = { version = "0.14.1", optional = true, features = [
+    "prometheus-encoding",
+] }
+prometheus = { version = "0.13.3", optional = true }
+opentelemetry_sdk = { version = "0.21.2", optional = true, features = [
+    "metrics",
+    "rt-tokio",
+] }
+hyper = { version = "0.14", features = ["full"], optional = true }
+tokio = { workspace = true, optional = true }

--- a/common/src/telemetry.rs
+++ b/common/src/telemetry.rs
@@ -1,19 +1,31 @@
 //! Provides helper functions for initializing telemetry collection and publication.
-use std::time::Duration;
+use std::{convert::Infallible, net::SocketAddr, sync::OnceLock, time::Duration};
 
 use anyhow::Result;
-use opentelemetry::{
-    runtime,
-    sdk::{
-        export::metrics::aggregation,
-        metrics::{controllers::BasicController, selectors},
-    },
+use hyper::{
+    body::Body,
+    http::HeaderValue,
+    service::{make_service_fn, service_fn},
+    Request, Response,
 };
+use opentelemetry::global;
 use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{
+    metrics::{
+        reader::{DefaultAggregationSelector, DefaultTemporalitySelector},
+        MeterProvider,
+    },
+    runtime, trace, Resource,
+};
+use prometheus::{Encoder, TextEncoder};
+use tokio::{sync::oneshot, task::JoinHandle};
 use tracing_subscriber::{filter::LevelFilter, prelude::*, EnvFilter, Registry};
 
-/// Initialize tracing and metrics
-pub async fn init(otlp_endpoint: String) -> Result<BasicController> {
+// create a new prometheus registry
+static PROM_REGISTRY: OnceLock<prometheus::Registry> = OnceLock::new();
+
+/// Initialize tracing
+pub async fn init_tracing(otlp_endpoint: String) -> Result<()> {
     let tracer = opentelemetry_otlp::new_pipeline()
         .tracing()
         .with_exporter(
@@ -21,44 +33,16 @@ pub async fn init(otlp_endpoint: String) -> Result<BasicController> {
                 .tonic()
                 .with_endpoint(otlp_endpoint.clone()),
         )
-        .with_trace_config(opentelemetry::sdk::trace::config().with_resource(
-            opentelemetry::sdk::Resource::new(vec![
+        .with_trace_config(trace::config().with_resource(Resource::new(vec![
                 opentelemetry::KeyValue::new(
                     "hostname",
                     gethostname::gethostname()
                         .into_string()
                         .expect("hostname should be valid utf-8"),
                 ),
-                opentelemetry::KeyValue::new(
-                "service.name",
-                "keramik",
-            )]),
-        ))
+                opentelemetry::KeyValue::new("service.name", "keramik"),
+            ])))
         .install_batch(runtime::Tokio)?;
-
-    let meter = opentelemetry_otlp::new_pipeline()
-        .metrics(
-            selectors::simple::histogram([1.0, 2.0, 5.0, 10.0, 20.0, 50.0]),
-            aggregation::cumulative_temporality_selector(),
-            runtime::Tokio,
-        )
-        .with_exporter(
-            opentelemetry_otlp::new_exporter()
-                .tonic()
-                .with_endpoint(otlp_endpoint),
-        )
-        .with_resource(opentelemetry::sdk::Resource::new(vec![
-            opentelemetry::KeyValue::new(
-                "hostname",
-                gethostname::gethostname()
-                    .into_string()
-                    .expect("hostname should be valid utf-8"),
-            ),
-            opentelemetry::KeyValue::new("service.name", "keramik"),
-        ]))
-        .with_period(Duration::from_secs(10))
-        // Build starts the meter and sets it as the global meter provider
-        .build()?;
 
     // Setup filters
     // Default to INFO if no env is specified
@@ -90,5 +74,93 @@ pub async fn init(otlp_endpoint: String) -> Result<BasicController> {
     // Initialize tracing
     tracing::subscriber::set_global_default(collector)?;
 
+    Ok(())
+}
+
+/// Initialize metrics such that metrics are pushed to the otlp_endpoint.
+pub async fn init_metrics_otlp(otlp_endpoint: String) -> Result<MeterProvider> {
+    // configure OpenTelemetry to use this registry
+    let meter = opentelemetry_otlp::new_pipeline()
+        .metrics(runtime::Tokio)
+        .with_exporter(
+            opentelemetry_otlp::new_exporter()
+                .tonic()
+                .with_endpoint(otlp_endpoint),
+        )
+        .with_resource(Resource::new(vec![
+            opentelemetry::KeyValue::new(
+                "hostname",
+                gethostname::gethostname()
+                    .into_string()
+                    .expect("hostname should be valid utf-8"),
+            ),
+            opentelemetry::KeyValue::new("service.name", "keramik"),
+        ]))
+        .with_period(Duration::from_secs(10))
+        .with_aggregation_selector(DefaultAggregationSelector::new())
+        .with_temporality_selector(DefaultTemporalitySelector::new())
+        // Build starts the meter and sets it as the global meter provider
+        .build()?;
+
     Ok(meter)
+}
+
+type MetricsServerShutdown = oneshot::Sender<()>;
+type MetricsServerJoin = JoinHandle<Result<(), hyper::Error>>;
+
+/// Initialize metrics such that metrics are expose via a Prometheus scrape endpoint.
+/// A send on the MetricsServerShutdown channel will cause the server to shutdown gracefully.
+pub async fn init_metrics_prom(
+    addr: &SocketAddr,
+) -> Result<(MeterProvider, MetricsServerShutdown, MetricsServerJoin)> {
+    let prom_registry = prometheus::Registry::default();
+    let prom_exporter = opentelemetry_prometheus::exporter()
+        .with_registry(prom_registry.clone())
+        .build()?;
+    PROM_REGISTRY
+        .set(prom_registry)
+        .expect("should be able to set PROM_REGISTRY");
+    let meter = MeterProvider::builder().with_reader(prom_exporter).build();
+    global::set_meter_provider(meter.clone());
+
+    let (shutdown, join) = start_metrics_server(addr);
+    Ok((meter, shutdown, join))
+}
+
+// /metrics scrape endpoin
+async fn handle(_req: Request<Body>) -> Result<Response<Body>, Infallible> {
+    let mut data = Vec::new();
+    let encoder = TextEncoder::new();
+    let metric_families = PROM_REGISTRY
+        .get()
+        .expect("PROM_REGISTRY should be initialized")
+        .gather();
+    encoder.encode(&metric_families, &mut data).unwrap();
+
+    // Add EOF marker, this is part of openmetrics spec but not prometheus
+    // So we have to add it ourselves.
+    // https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#overall-structure
+    data.extend(b"# EOF\n");
+
+    let mut resp = Response::new(Body::from(data));
+    resp.headers_mut().insert(
+        "Content-Type",
+        // Use OpenMetrics content type so prometheus knows to parse it accordingly
+        HeaderValue::from_static("application/openmetrics-text"),
+    );
+    Ok(resp)
+}
+
+// Start metrics server.
+// Sending on the returned channel will cause the server to shutdown gracefully.
+fn start_metrics_server(addr: &SocketAddr) -> (MetricsServerShutdown, MetricsServerJoin) {
+    let (tx, rx) = oneshot::channel::<()>();
+    let service = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });
+
+    let server = hyper::Server::bind(addr)
+        .serve(service)
+        .with_graceful_shutdown(async {
+            rx.await.ok();
+        });
+    (tx, tokio::spawn(server))
 }

--- a/common/src/telemetry.rs
+++ b/common/src/telemetry.rs
@@ -127,7 +127,7 @@ pub async fn init_metrics_prom(
     Ok((meter, shutdown, join))
 }
 
-// /metrics scrape endpoin
+// /metrics scrape endpoint.
 async fn handle(_req: Request<Body>) -> Result<Response<Body>, Infallible> {
     let mut data = Vec::new();
     let encoder = TextEncoder::new();

--- a/k8s/operator/manifests/operator.yaml
+++ b/k8s/operator/manifests/operator.yaml
@@ -70,6 +70,10 @@ spec:
     targetPort: 8080
     protocol: TCP
     name: http
+  - port: 9464
+    targetPort: 9464
+    protocol: TCP
+    name: metrics
   selector:
     app: keramik-operator
 ---
@@ -118,6 +122,9 @@ spec:
         ports:
         - name: http
           containerPort: 8080
+          protocol: TCP
+        - name: metrics
+          containerPort: 9464
           protocol: TCP
         env:
         # We are pointing to tempo or grafana tracing agent's otlp grpc receiver port

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -31,6 +31,7 @@ use kube::{
     },
     Resource,
 };
+use opentelemetry::global;
 use rand::RngCore;
 use tracing::{debug, error, info, trace, warn};
 
@@ -202,6 +203,13 @@ async fn reconcile(
     network: Arc<Network>,
     cx: Arc<Context<impl IpfsRpcClient, impl RngCore, impl Clock>>,
 ) -> Result<Action, Error> {
+    let meter = global::meter("keramik");
+    let runs = meter
+        .u64_counter("network_reconcile_count")
+        .with_description("Number of network reconciles")
+        .init();
+    runs.add(1, &[]);
+
     let spec = network.spec();
     debug!(?spec, "reconcile");
 


### PR DESCRIPTION
Now the operator exposes a prometheus scrape endpoint. It does not try to push its metrics over OTLP. This operator is long lived so this should not be a problem.

The runner continues to push its metrics over OTLP which is important since it is short lived.

However I was not able to get both prometheus scrape and OTLP push working on the same process. So the operator only supports prometheus and the runner only support OTLP push.