### PR TITLE
feat: add podmonitor crd for keramik operator deployments

### DIFF
--- a/k8s/operator/manifests/podmonitor.yaml
+++ b/k8s/operator/manifests/podmonitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: keramik-operator
+spec:
+  podMetricsEndpoints:
+  - interval: 10s
+    path: /metrics
+    targetPort: 9464
+  selector:
+    matchLabels:
+      app: keramik-operator


### PR DESCRIPTION
Adds a podmonitor CRD to capture keramik operator metrics.

Deployments would add this resource to their kustomization.yaml to enable.