### PR TITLE
fix: use new recon key metric name

### DIFF
--- a/runner/src/simulate.rs
+++ b/runner/src/simulate.rs
@@ -24,7 +24,7 @@ use crate::{
 
 // FIXME: is it worth attaching metrics to the peer info?
 const IPFS_SERVICE_METRICS_PORT: u32 = 9465;
-const EVENT_SYNC_METRIC_NAME: &str = "recon_key_insert_count_total";
+const EVENT_SYNC_METRIC_NAME: &str = "ceramic_store_key_insert_count_total";
 
 /// Options to Simulate command
 #[derive(Args, Debug)]


### PR DESCRIPTION
Adjusts metric used for event sync success criteria based on [the rename](https://github.com/ceramicnetwork/rust-ceramic/pull/266) in rust ceramic