### PR TITLE
fix: add n/w check for cas ipfs during peer status updates

### DIFF
--- a/operator/src/network/ipfs_rpc.rs
+++ b/operator/src/network/ipfs_rpc.rs
@@ -14,7 +14,7 @@ pub trait IpfsRpcClient {
 /// Information about connected peers
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct Peer {
-    pub addr: String,
+    #[serde(rename = "Peer")]
     pub id: String,
 }
 


### PR DESCRIPTION
CAS IPFS status lookup for durable networks pointing to external CAS is causing peer status reconciliation to fail.

I've only tested this on the Clay/Prod cluster so far, but their tests are now green!

https://github.com/3box/ceramic-tests/actions/runs/7848110468
https://github.com/3box/ceramic-tests/actions/runs/7848846872