### PR TITLE
feat: adds node-affinity spec config

### DIFF
--- a/operator/src/network/bootstrap.rs
+++ b/operator/src/network/bootstrap.rs
@@ -5,7 +5,7 @@ use k8s_openapi::api::{
     },
 };
 
-use crate::network::{BootstrapSpec, PEERS_CONFIG_MAP_NAME};
+use crate::network::{node_affinity::NodeAffinityConfig, BootstrapSpec, PEERS_CONFIG_MAP_NAME};
 
 // BootstrapConfig defines which properties of the JobSpec can be customized.
 pub struct BootstrapConfig {
@@ -51,11 +51,14 @@ impl From<BootstrapSpec> for BootstrapConfig {
     }
 }
 
-pub fn bootstrap_job_spec(config: BootstrapConfig) -> JobSpec {
+pub fn bootstrap_job_spec(
+    config: BootstrapConfig,
+    node_affinity_config: &NodeAffinityConfig,
+) -> JobSpec {
     debug_assert!(config.enabled);
     JobSpec {
         backoff_limit: Some(4),
-        template: PodTemplateSpec {
+        template: node_affinity_config.apply_to_pod_template(PodTemplateSpec {
             spec: Some(PodSpec {
                 containers: vec![Container {
                     name: "bootstrap".to_owned(),
@@ -112,7 +115,7 @@ pub fn bootstrap_job_spec(config: BootstrapConfig) -> JobSpec {
                 ..Default::default()
             }),
             ..Default::default()
-        },
+        }),
         ..Default::default()
     }
 }

--- a/operator/src/network/mod.rs
+++ b/operator/src/network/mod.rs
@@ -1,6 +1,7 @@
 //! Network is k8s custom resource that defines a Ceramic network.
 
 // Export all spec types
+mod node_affinity;
 mod spec;
 pub use spec::*;
 

--- a/operator/src/network/mod.rs
+++ b/operator/src/network/mod.rs
@@ -1,7 +1,6 @@
 //! Network is k8s custom resource that defines a Ceramic network.
 
 // Export all spec types
-mod node_affinity;
 mod spec;
 pub use spec::*;
 
@@ -20,6 +19,8 @@ pub(crate) mod datadog;
 pub(crate) mod ipfs;
 #[cfg(feature = "controller")]
 pub(crate) mod ipfs_rpc;
+#[cfg(feature = "controller")]
+mod node_affinity;
 #[cfg(feature = "controller")]
 pub(crate) mod peers;
 #[cfg(feature = "controller")]

--- a/operator/src/network/node_affinity.rs
+++ b/operator/src/network/node_affinity.rs
@@ -1,0 +1,42 @@
+use k8s_openapi::api::core::v1::{Affinity, NodeAffinity, NodeSelector, PodSpec, PodTemplateSpec};
+
+use super::NetworkSpec;
+
+#[derive(Default)]
+pub struct NodeAffinityConfig {
+    node_selector_terms: Option<Vec<k8s_openapi::api::core::v1::NodeSelectorTerm>>,
+}
+
+impl NodeAffinityConfig {
+    pub fn apply_to_pod_template(&self, pod_template: PodTemplateSpec) -> PodTemplateSpec {
+        if let Some(node_selector_terms) = &self.node_selector_terms {
+            PodTemplateSpec {
+                spec: pod_template.spec.map(|spec| PodSpec {
+                    affinity: Some(Affinity {
+                        node_affinity: Some(NodeAffinity {
+                            required_during_scheduling_ignored_during_execution: Some(
+                                NodeSelector {
+                                    node_selector_terms: node_selector_terms.clone(),
+                                },
+                            ),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    ..spec
+                }),
+                ..pod_template
+            }
+        } else {
+            pod_template
+        }
+    }
+}
+
+impl From<&NetworkSpec> for NodeAffinityConfig {
+    fn from(value: &NetworkSpec) -> Self {
+        Self {
+            node_selector_terms: value.node_selector_terms.clone(),
+        }
+    }
+}

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -52,6 +52,10 @@ pub struct NetworkSpec {
     pub dev_mode: Option<bool>,
     /// Enable monitoring resources to be deployed into the network.
     pub monitoring: Option<MonitoringSpec>,
+    /// A list of node selector terms. These node select terms will be applied to all pods in the network.
+    /// As such you must ensure that the selected nodes have the capacity to handle the entire
+    /// network workload.
+    pub node_selector_terms: Option<Vec<k8s_openapi::api::core::v1::NodeSelectorTerm>>,
 }
 
 /// Local network ID.


### PR DESCRIPTION
When node_selector_terms is set on a network all pods in the network will use those terms in order to control on which nodes the networks pods are scheduled.

This does not affect pods in simulations. I can add that if its needed/wanted.