### PR TITLE
fix: no longer reuse the secret from cas for ceramic

### DIFF
--- a/operator/src/network/cas.rs
+++ b/operator/src/network/cas.rs
@@ -16,21 +16,22 @@ use k8s_openapi::{
 };
 use kube::core::ObjectMeta;
 
-use crate::network::{
-    ceramic::NetworkConfig,
-    controller::{
-        CAS_APP, CAS_IPFS_APP, CAS_IPFS_SERVICE_NAME, CAS_POSTGRES_APP, CAS_POSTGRES_SERVICE_NAME,
-        CAS_SERVICE_NAME, GANACHE_APP, GANACHE_SERVICE_NAME, LOCALSTACK_APP,
-        LOCALSTACK_SERVICE_NAME, NETWORK_DEV_MODE_RESOURCES,
-    },
-    datadog::DataDogConfig,
-    ipfs::{IpfsConfig, IPFS_DATA_PV_CLAIM},
-    resource_limits::ResourceLimitsConfig,
-    CasSpec,
-};
 use crate::{
     labels::{managed_labels, selector_labels},
-    network::{ipfs::IpfsInfo, node_affinity::NodeAffinityConfig},
+    network::{
+        ceramic::NetworkConfig,
+        controller::{
+            CAS_APP, CAS_IPFS_APP, CAS_IPFS_SERVICE_NAME, CAS_POSTGRES_APP,
+            CAS_POSTGRES_SECRET_NAME, CAS_POSTGRES_SERVICE_NAME, CAS_SERVICE_NAME, GANACHE_APP,
+            GANACHE_SERVICE_NAME, LOCALSTACK_APP, LOCALSTACK_SERVICE_NAME,
+            NETWORK_DEV_MODE_RESOURCES,
+        },
+        datadog::DataDogConfig,
+        ipfs::{IpfsConfig, IpfsInfo, IPFS_DATA_PV_CLAIM},
+        node_affinity::NodeAffinityConfig,
+        resource_limits::ResourceLimitsConfig,
+        CasSpec,
+    },
 };
 
 const CAS_IPFS_INFO_SUFFIX: &str = "cas";
@@ -158,7 +159,7 @@ pub fn cas_stateful_set_spec(
             value_from: Some(EnvVarSource {
                 secret_key_ref: Some(SecretKeySelector {
                     key: "username".to_owned(),
-                    name: Some("postgres-auth".to_owned()),
+                    name: Some(CAS_POSTGRES_SECRET_NAME.to_string()),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -170,7 +171,7 @@ pub fn cas_stateful_set_spec(
             value_from: Some(EnvVarSource {
                 secret_key_ref: Some(SecretKeySelector {
                     key: "password".to_owned(),
-                    name: Some("postgres-auth".to_owned()),
+                    name: Some(CAS_POSTGRES_SECRET_NAME.to_string()),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -737,7 +738,7 @@ pub fn postgres_stateful_set_spec(
                             value_from: Some(EnvVarSource {
                                 secret_key_ref: Some(SecretKeySelector {
                                     key: "password".to_owned(),
-                                    name: Some("postgres-auth".to_owned()),
+                                    name: Some(CAS_POSTGRES_SECRET_NAME.to_string()),
                                     ..Default::default()
                                 }),
                                 ..Default::default()
@@ -749,7 +750,7 @@ pub fn postgres_stateful_set_spec(
                             value_from: Some(EnvVarSource {
                                 secret_key_ref: Some(SecretKeySelector {
                                     key: "username".to_owned(),
-                                    name: Some("postgres-auth".to_owned()),
+                                    name: Some(CAS_POSTGRES_SECRET_NAME.to_string()),
                                     ..Default::default()
                                 }),
                                 ..Default::default()

--- a/operator/src/network/ceramic.rs
+++ b/operator/src/network/ceramic.rs
@@ -21,8 +21,9 @@ use crate::{
     labels::{managed_labels, selector_labels},
     network::{
         controller::{
-            CAS_SERVICE_NAME, CERAMIC_APP, CERAMIC_SERVICE_API_PORT, CERAMIC_SERVICE_IPFS_PORT,
-            GANACHE_SERVICE_NAME, INIT_CONFIG_MAP_NAME, NETWORK_DEV_MODE_RESOURCES,
+            CAS_SERVICE_NAME, CERAMIC_APP, CERAMIC_POSTGRES_SECRET_NAME, CERAMIC_SERVICE_API_PORT,
+            CERAMIC_SERVICE_IPFS_PORT, GANACHE_SERVICE_NAME, INIT_CONFIG_MAP_NAME,
+            NETWORK_DEV_MODE_RESOURCES,
         },
         datadog::DataDogConfig,
         ipfs::{IpfsConfig, IpfsInfo, IPFS_DATA_PV_CLAIM},
@@ -358,7 +359,7 @@ pub fn stateful_set_spec(ns: &str, bundle: &CeramicBundle<'_>) -> StatefulSetSpe
             value_from: Some(EnvVarSource {
                 secret_key_ref: Some(SecretKeySelector {
                     key: "username".to_owned(),
-                    name: Some("postgres-auth".to_owned()),
+                    name: Some(CERAMIC_POSTGRES_SECRET_NAME.to_string()),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -370,7 +371,7 @@ pub fn stateful_set_spec(ns: &str, bundle: &CeramicBundle<'_>) -> StatefulSetSpe
             value_from: Some(EnvVarSource {
                 secret_key_ref: Some(SecretKeySelector {
                     key: "password".to_owned(),
-                    name: Some("postgres-auth".to_owned()),
+                    name: Some(CERAMIC_POSTGRES_SECRET_NAME.to_string()),
                     ..Default::default()
                 }),
                 ..Default::default()
@@ -582,7 +583,7 @@ pub fn stateful_set_spec(ns: &str, bundle: &CeramicBundle<'_>) -> StatefulSetSpe
                                     value_from: Some(EnvVarSource {
                                         secret_key_ref: Some(SecretKeySelector {
                                             key: "password".to_owned(),
-                                            name: Some("postgres-auth".to_owned()),
+                                            name: Some(CERAMIC_POSTGRES_SECRET_NAME.to_string()),
                                             ..Default::default()
                                         }),
                                         ..Default::default()
@@ -594,7 +595,7 @@ pub fn stateful_set_spec(ns: &str, bundle: &CeramicBundle<'_>) -> StatefulSetSpe
                                     value_from: Some(EnvVarSource {
                                         secret_key_ref: Some(SecretKeySelector {
                                             key: "username".to_owned(),
-                                            name: Some("postgres-auth".to_owned()),
+                                            name: Some(CERAMIC_POSTGRES_SECRET_NAME.to_string()),
                                             ..Default::default()
                                         }),
                                         ..Default::default()

--- a/operator/src/network/testdata/ceramic_go_ss_1
+++ b/operator/src/network/testdata/ceramic_go_ss_1
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -321,7 +321,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -330,7 +330,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },

--- a/operator/src/network/testdata/ceramic_ss_1
+++ b/operator/src/network/testdata/ceramic_ss_1
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -354,7 +354,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -363,7 +363,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },

--- a/operator/src/network/testdata/ceramic_ss_weighted_0
+++ b/operator/src/network/testdata/ceramic_ss_weighted_0
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -354,7 +354,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -363,7 +363,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },

--- a/operator/src/network/testdata/ceramic_ss_weighted_1
+++ b/operator/src/network/testdata/ceramic_ss_weighted_1
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -354,7 +354,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -363,7 +363,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },

--- a/operator/src/network/testdata/ceramic_ss_weighted_2
+++ b/operator/src/network/testdata/ceramic_ss_weighted_2
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -354,7 +354,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -363,7 +363,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },

--- a/operator/src/network/testdata/ceramic_ss_weighted_3
+++ b/operator/src/network/testdata/ceramic_ss_weighted_3
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -354,7 +354,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -363,7 +363,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },

--- a/operator/src/network/testdata/ceramic_ss_weighted_4
+++ b/operator/src/network/testdata/ceramic_ss_weighted_4
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -354,7 +354,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -363,7 +363,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },

--- a/operator/src/network/testdata/ceramic_ss_weighted_5
+++ b/operator/src/network/testdata/ceramic_ss_weighted_5
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -354,7 +354,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -363,7 +363,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },

--- a/operator/src/network/testdata/ceramic_ss_weighted_6
+++ b/operator/src/network/testdata/ceramic_ss_weighted_6
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -354,7 +354,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -363,7 +363,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },

--- a/operator/src/network/testdata/ceramic_ss_weighted_7
+++ b/operator/src/network/testdata/ceramic_ss_weighted_7
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -354,7 +354,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -363,7 +363,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },

--- a/operator/src/network/testdata/ceramic_ss_weighted_8
+++ b/operator/src/network/testdata/ceramic_ss_weighted_8
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -354,7 +354,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -363,7 +363,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },

--- a/operator/src/network/testdata/ceramic_ss_weighted_9
+++ b/operator/src/network/testdata/ceramic_ss_weighted_9
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -354,7 +354,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -363,7 +363,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },

--- a/operator/src/network/testdata/default_stubs/ceramic_postgres_auth_secret
+++ b/operator/src/network/testdata/default_stubs/ceramic_postgres_auth_secret
@@ -1,0 +1,6 @@
+Request {
+    method: "GET",
+    uri: "/api/v1/namespaces/keramik-test/secrets/ceramic-postgres-auth",
+    headers: {},
+    body: ,
+}

--- a/operator/src/network/testdata/default_stubs/ceramic_stateful_set
+++ b/operator/src/network/testdata/default_stubs/ceramic_stateful_set
@@ -86,7 +86,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -95,7 +95,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -170,7 +170,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -179,7 +179,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   }
@@ -354,7 +354,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "username",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },
@@ -363,7 +363,7 @@ Request {
                     "valueFrom": {
                       "secretKeyRef": {
                         "key": "password",
-                        "name": "postgres-auth"
+                        "name": "ceramic-postgres-auth"
                       }
                     }
                   },


### PR DESCRIPTION
If CAS was not configured then ceramic postgres would not have a secret. Now they each have their own secret.