### PR TITLE
fix: no default otel endpoint for the operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,7 +2915,6 @@ dependencies = [
  "tokio",
  "tower-test",
  "tracing",
- "tracing-log 0.1.4",
  "tracing-test",
 ]
 
@@ -2944,7 +2943,6 @@ dependencies = [
  "test-log",
  "tokio",
  "tracing",
- "tracing-log 0.1.4",
  "tracing-subscriber",
 ]
 
@@ -6531,17 +6529,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -6564,7 +6551,7 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
@@ -6596,7 +6583,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,11 @@ tokio = { version = "1", features = ["full", "tracing"] }
 tonic = { version = "0.8" }
 tracing = "0.1.37"
 tracing-opentelemetry = "0.22"
-tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
-tracing-log = "0.1.3"
+tracing-subscriber = { version = "0.3", features = [
+    "json",
+    "env-filter",
+    "tracing-log",
+] }
 
 [patch.crates-io]
 goose = { git = "https://github.com/3box/goose.git", branch = "feat/all-metrics-digest" }

--- a/k8s/operator/manifests/operator.yaml
+++ b/k8s/operator/manifests/operator.yaml
@@ -127,9 +127,6 @@ spec:
           containerPort: 9464
           protocol: TCP
         env:
-        # We are pointing to tempo or grafana tracing agent's otlp grpc receiver port
-        - name: OPERATOR_OTLP_ENDPOINT
-          value: "https://otel:4317"
         - name: RUST_LOG
           value: "info"
         #readinessProbe:

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -33,7 +33,6 @@ controller = [
     "dep:thiserror",
     "dep:tokio",
     "dep:tracing",
-    "dep:tracing-log",
     # Enable keramik-common/telemetry feature if the controller is enabled.
     "keramik-common/telemetry",
     "kube/client",
@@ -69,7 +68,6 @@ serde_yaml = { version = "0.9.21", optional = true }
 thiserror = { version = "1", optional = true }
 tokio = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
-tracing-log = { workspace = true, optional = true }
 
 [dev-dependencies]
 expect-patch.workspace = true

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -11,12 +11,8 @@ struct Cli {
     #[command(subcommand)]
     command: Command,
 
-    #[arg(
-        long,
-        env = "OPERATOR_OTLP_ENDPOINT",
-        default_value = "http://localhost:4317"
-    )]
-    otlp_endpoint: String,
+    #[arg(long, env = "OPERATOR_OTLP_ENDPOINT")]
+    otlp_endpoint: Option<String>,
 
     #[arg(long, env = "OPERATOR_PROM_BIND", default_value = "0.0.0.0:9464")]
     prom_bind: String,
@@ -34,7 +30,9 @@ async fn main() -> Result<()> {
     tracing_log::LogTracer::init()?;
 
     let args = Cli::parse();
-    telemetry::init_tracing(args.otlp_endpoint.clone()).await?;
+    if let Some(otlp_endpoint) = &args.otlp_endpoint {
+        telemetry::init_tracing(otlp_endpoint.clone()).await?;
+    }
     let (metrics_controller, metrics_server_shutdown, metrics_server_join) =
         telemetry::init_metrics_prom(&args.prom_bind.parse()?).await?;
 

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -26,11 +26,9 @@ schemars = "0.8.12"
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-tracing-log.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 multibase.workspace = true
 
 [dev-dependencies]
 test-log = "0.2"
-

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -65,11 +65,10 @@ pub enum CommandResult {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_log::LogTracer::init()?;
-
     let args = Cli::parse();
-    telemetry::init_tracing(args.otlp_endpoint.clone()).await?;
+    telemetry::init_tracing(Some(args.otlp_endpoint.clone())).await?;
     let metrics_controller = telemetry::init_metrics_otlp(args.otlp_endpoint.clone()).await?;
+    info!("starting runner");
 
     let meter = global::meter("keramik");
     let runs = meter


### PR DESCRIPTION
The operator no longer has a default opentelemetry endpoint and will only collect and send traces if an endpoint is configured.

This might address the memory leak but either way its a nice quality of life improvement as we have not been collecting traces from the operator anyway.