### PR TITLE
feat: disable tracing in default deploy

### DIFF
--- a/k8s/operator/manifests/operator.yaml
+++ b/k8s/operator/manifests/operator.yaml
@@ -127,9 +127,6 @@ spec:
           containerPort: 9464
           protocol: TCP
         env:
-        # We are pointing to tempo or grafana tracing agent's otlp grpc receiver port
-        - name: OPERATOR_OTLP_ENDPOINT
-          value: "https://otel:4317"
         - name: RUST_LOG
           value: "info"
         #readinessProbe:


### PR DESCRIPTION
The production deployments pull from this deployment, disabling here will disable those installs (on update).