### PR TITLE
feat: pod monitoring

### DIFF
--- a/k8s/operator/manifests/operator.yaml
+++ b/k8s/operator/manifests/operator.yaml
@@ -38,6 +38,12 @@ rules:
   - apiGroups: ["keramik.3box.io"]
     resources: ["networks", "networks/status", "simulations", "simulations/status"]
     verbs: ["get", "list", "watch", "patch", "delete"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["podmonitors"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
 ---
 # Binding the role to the account
 kind: ClusterRoleBinding

--- a/keramik/src/monitoring.md
+++ b/keramik/src/monitoring.md
@@ -44,7 +44,14 @@ Scrape the `otel:9465` endpoint if you want on the simulation metrics.
 
 ## Pod Monitoring
 
-If pod monitoring is enabled, the operator will create custom resources for monitoring the network pods. The Grafana
-Cloud Agent will then consume this configuration and send the metrics to Grafana Cloud.
-
 This option expects the `PodMonitor` custom resource definition to already be installed in the network namespace.
+
+If `podMonitor` is enabled, the operator will create `podmonitors.monitoring.coreos.com` resources for collecting the metrics from the pods in the network.
+
+If you're using something like the grafana cloud agent, or prometheus-operator, the `podmonitors.monitoring.coreos.com` will be installed already.
+
+You can install the CRD directly from the operator:
+
+```
+    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+```

--- a/keramik/src/monitoring.md
+++ b/keramik/src/monitoring.md
@@ -18,6 +18,7 @@ spec:
   replicas: 2
   monitoring:
     namespaced: true
+    podMonitor: true
 ```
 
 To view the metrics and traces port-forward the services:
@@ -40,3 +41,10 @@ This is typically a collection of metrics per simulation run and is much lighter
 Scrape the `otel:9465` endpoint if you want on the simulation metrics.
 
 >NOTE: The prometheus-0 pod will scrape all metrics so you can easily inspect all activity on the network.
+
+## Pod Monitoring
+
+If pod monitoring is enabled, the operator will create custom resources for monitoring the network pods. The Grafana
+Cloud Agent will then consume this configuration and send the metrics to Grafana Cloud.
+
+This option expects the `PodMonitor` custom resource definition to already be installed in the network namespace.

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -1027,7 +1027,8 @@ async fn apply_pod_monitor(
 ) -> Result<(), Error> {
     // Create the pod monitor CR only if the CRD already exists
     let crds: Api<CustomResourceDefinition> = Api::all(cx.k_client.clone());
-    let crd = crds.get(PodMonitor::crd_name()).await;
+    let crd_name = PodMonitor::crd_name();
+    let crd = crds.get(crd_name).await;
     if crd.is_ok() {
         // Instantiate the pod monitor CR if it doesn't already exist
         let ns = "keramik-".to_owned() + &network.name_any();
@@ -1060,8 +1061,10 @@ async fn apply_pod_monitor(
         }
     } else {
         warn!(
-            "{} pod monitor instance requested but CRD not installed",
-            monitor_name
+            "{} pod monitor instance requested but CRD {} not found: {}",
+            monitor_name,
+            crd_name,
+            crd.unwrap_err()
         );
     }
     Ok(())

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -266,7 +266,17 @@ pub struct MonitoringSpec {
     /// Deploy monitoring resources into the network namespace directly
     pub namespaced: Option<bool>,
     /// Deploy pod monitors
-    pub pod_monitoring: Option<bool>,
+    pub pod_monitoring: Option<PodMonitoringSpec>,
+}
+
+/// Describes the pod monitor configuration
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PodMonitoringSpec {
+    /// Whether pod monitoring is enabled
+    pub enabled: Option<bool>,
+    /// Labels transferred from the pod onto the ingested metrics
+    pub pod_target_labels: Option<Vec<String>>,
 }
 
 /// CRD for pod monitors.
@@ -281,9 +291,11 @@ pub struct MonitoringSpec {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct PodMonitorSpec {
-    /// The pod monitor endpoint specs
+    /// List of endpoints that are part of this monitor
     pub pod_metrics_endpoints: Vec<PodMetricsEndpointSpec>,
-    /// The selector for the pod to monitor
+    /// Labels transferred from the pod onto the ingested metrics
+    pub pod_target_labels: Option<Vec<String>>,
+    /// Label selector to select pods
     pub selector: Option<SelectorSpec>,
 }
 

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -265,4 +265,44 @@ pub struct ResourceLimitsSpec {
 pub struct MonitoringSpec {
     /// Deploy monitoring resources into the network namespace directly
     pub namespaced: Option<bool>,
+    /// Deploy pod monitors
+    pub pod_monitoring: Option<bool>,
+}
+
+/// CRD for pod monitors.
+#[derive(CustomResource, Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
+#[kube(
+    group = "monitoring.coreos.com",
+    version = "v1",
+    kind = "PodMonitor",
+    plural = "podmonitors",
+    namespaced,
+    derive = "PartialEq"
+)]
+#[serde(rename_all = "camelCase")]
+pub struct PodMonitorSpec {
+    /// The pod monitor endpoint specs
+    pub pod_metrics_endpoints: Vec<PodMetricsEndpointSpec>,
+    /// The selector for the pod to monitor
+    pub selector: Option<SelectorSpec>,
+}
+
+/// Describes the pod monitor endpoint
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PodMetricsEndpointSpec {
+    /// Monitoring interval
+    pub interval: Option<String>,
+    /// Monitoring path
+    pub path: Option<String>,
+    /// Monitoring port
+    pub target_port: Option<u32>,
+}
+
+/// Describes the selector for the pod monitor
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectorSpec {
+    /// The selector match labels
+    pub match_labels: BTreeMap<String, String>,
 }

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -266,13 +266,13 @@ pub struct MonitoringSpec {
     /// Deploy monitoring resources into the network namespace directly
     pub namespaced: Option<bool>,
     /// Deploy pod monitors
-    pub pod_monitoring: Option<PodMonitoringSpec>,
+    pub pod_monitor: Option<PodMonitorSpec>,
 }
 
 /// Describes the pod monitor configuration
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct PodMonitoringSpec {
+pub struct PodMonitorSpec {
     /// Whether pod monitoring is enabled
     pub enabled: Option<bool>,
     /// Labels transferred from the pod onto the ingested metrics
@@ -290,7 +290,7 @@ pub struct PodMonitoringSpec {
     derive = "PartialEq"
 )]
 #[serde(rename_all = "camelCase")]
-pub struct PodMonitorSpec {
+pub struct PodMonitorCrd {
     /// List of endpoints that are part of this monitor
     pub pod_metrics_endpoints: Vec<PodMetricsEndpointSpec>,
     /// Labels transferred from the pod onto the ingested metrics

--- a/operator/src/network/stub.rs
+++ b/operator/src/network/stub.rs
@@ -7,11 +7,14 @@ use k8s_openapi::api::{
     batch::v1::Job,
     core::v1::{Pod, Secret, Service},
 };
-use kube::core::{ListMeta, ObjectList, TypeMeta};
+use kube::{
+    core::{ListMeta, ObjectList, TypeMeta},
+    CustomResourceExt,
+};
 
 use crate::{
     labels::managed_labels,
-    network::{Network, NetworkSpec, NetworkStatus},
+    network::{Network, NetworkSpec, NetworkStatus, PodMonitor, PodMonitorSpec},
     utils::test::{ApiServerVerifier, WithStatus},
 };
 
@@ -56,6 +59,11 @@ pub struct Stub {
     pub namespace: ExpectPatch<ExpectFile>,
     pub status: ExpectPatch<ExpectFile>,
     pub monitoring: Vec<ExpectFile>,
+    pub pod_monitor: Vec<(
+        (ExpectFile, bool),
+        Option<(ExpectFile, bool)>,
+        Option<ExpectFile>,
+    )>,
     pub cas_postgres_auth_secret: (ExpectPatch<ExpectFile>, Secret, bool),
     pub ceramic_postgres_auth_secret: (ExpectPatch<ExpectFile>, Secret),
     pub ceramic_admin_secret_missing: (ExpectPatch<ExpectFile>, Option<Secret>),
@@ -95,6 +103,7 @@ impl Default for Stub {
             namespace: expect_file!["./testdata/default_stubs/namespace"].into(),
             status: expect_file!["./testdata/default_stubs/status"].into(),
             monitoring: vec![],
+            pod_monitor: vec![],
             cas_postgres_auth_secret: (
                 expect_file!["./testdata/default_stubs/postgres_auth_secret"].into(),
                 k8s_openapi::api::core::v1::Secret {
@@ -217,6 +226,37 @@ impl Stub {
             .handle_apply(self.namespace)
             .await
             .expect("namespace should apply");
+        for ((crd_get, crd_exists), monitor_get, monitor_post) in self.pod_monitor {
+            let crd = if crd_exists {
+                Some(PodMonitor::crd())
+            } else {
+                None
+            };
+            fakeserver
+                .handle_request_response(crd_get, crd.as_ref())
+                .await
+                .expect("pod monitor crd should fetch");
+            if let Some((monitor_get, monitor_exists)) = monitor_get {
+                let monitor = if monitor_exists {
+                    Some(PodMonitor::new("test", PodMonitorSpec::default()))
+                } else {
+                    None
+                };
+                fakeserver
+                    .handle_request_response(monitor_get, monitor.as_ref())
+                    .await
+                    .expect("pod monitor should fetch");
+            }
+            if let Some(monitor_post) = monitor_post {
+                fakeserver
+                    .handle_request_response(
+                        monitor_post,
+                        Some(&PodMonitor::new("test", PodMonitorSpec::default())),
+                    )
+                    .await
+                    .expect("pod monitor should create");
+            }
+        }
         for otel in self.monitoring {
             fakeserver
                 .handle_apply(otel)

--- a/operator/src/network/stub.rs
+++ b/operator/src/network/stub.rs
@@ -14,7 +14,7 @@ use kube::{
 
 use crate::{
     labels::managed_labels,
-    network::{Network, NetworkSpec, NetworkStatus, PodMonitor, PodMonitorSpec},
+    network::{Network, NetworkSpec, NetworkStatus, PodMonitor, PodMonitorCrd},
     utils::test::{ApiServerVerifier, WithStatus},
 };
 
@@ -238,7 +238,7 @@ impl Stub {
                 .expect("pod monitor crd should fetch");
             if let Some((monitor_get, monitor_exists)) = monitor_get {
                 let monitor = if monitor_exists {
-                    Some(PodMonitor::new("test", PodMonitorSpec::default()))
+                    Some(PodMonitor::new("test", PodMonitorCrd::default()))
                 } else {
                     None
                 };
@@ -251,7 +251,7 @@ impl Stub {
                 fakeserver
                     .handle_request_response(
                         monitor_post,
-                        Some(&PodMonitor::new("test", PodMonitorSpec::default())),
+                        Some(&PodMonitor::new("test", PodMonitorCrd::default())),
                     )
                     .await
                     .expect("pod monitor should create");

--- a/operator/src/network/testdata/pod_monitor_get_ceramic
+++ b/operator/src/network/testdata/pod_monitor_get_ceramic
@@ -1,0 +1,6 @@
+Request {
+    method: "GET",
+    uri: "/apis/monitoring.coreos.com/v1/namespaces/keramik-test/podmonitors/ceramic",
+    headers: {},
+    body: ,
+}

--- a/operator/src/network/testdata/pod_monitor_get_ceramic_one
+++ b/operator/src/network/testdata/pod_monitor_get_ceramic_one
@@ -1,0 +1,6 @@
+Request {
+    method: "GET",
+    uri: "/apis/monitoring.coreos.com/v1/namespaces/keramik-test/podmonitors/ceramic-one",
+    headers: {},
+    body: ,
+}

--- a/operator/src/network/testdata/pod_monitor_get_crd
+++ b/operator/src/network/testdata/pod_monitor_get_crd
@@ -1,0 +1,6 @@
+Request {
+    method: "GET",
+    uri: "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/podmonitors.monitoring.coreos.com",
+    headers: {},
+    body: ,
+}

--- a/operator/src/network/testdata/pod_monitor_get_otel
+++ b/operator/src/network/testdata/pod_monitor_get_otel
@@ -1,0 +1,6 @@
+Request {
+    method: "GET",
+    uri: "/apis/monitoring.coreos.com/v1/namespaces/keramik-test/podmonitors/otel",
+    headers: {},
+    body: ,
+}

--- a/operator/src/network/testdata/pod_monitor_post_ceramic
+++ b/operator/src/network/testdata/pod_monitor_post_ceramic
@@ -18,6 +18,11 @@ Request {
             "targetPort": 9464
           }
         ],
+        "podTargetLabels": [
+          "affinity",
+          "scenario",
+          "simulation"
+        ],
         "selector": {
           "matchLabels": {
             "app": "ceramic"

--- a/operator/src/network/testdata/pod_monitor_post_ceramic
+++ b/operator/src/network/testdata/pod_monitor_post_ceramic
@@ -1,0 +1,28 @@
+Request {
+    method: "POST",
+    uri: "/apis/monitoring.coreos.com/v1/namespaces/keramik-test/podmonitors?",
+    headers: {
+        "content-type": "application/json",
+    },
+    body: {
+      "apiVersion": "monitoring.coreos.com/v1",
+      "kind": "PodMonitor",
+      "metadata": {
+        "name": "ceramic"
+      },
+      "spec": {
+        "podMetricsEndpoints": [
+          {
+            "interval": "10s",
+            "path": "/metrics",
+            "targetPort": 9464
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "app": "ceramic"
+          }
+        }
+      }
+    },
+}

--- a/operator/src/network/testdata/pod_monitor_post_ceramic_one
+++ b/operator/src/network/testdata/pod_monitor_post_ceramic_one
@@ -18,6 +18,11 @@ Request {
             "targetPort": 9465
           }
         ],
+        "podTargetLabels": [
+          "affinity",
+          "scenario",
+          "simulation"
+        ],
         "selector": {
           "matchLabels": {
             "app": "ceramic"

--- a/operator/src/network/testdata/pod_monitor_post_ceramic_one
+++ b/operator/src/network/testdata/pod_monitor_post_ceramic_one
@@ -1,0 +1,28 @@
+Request {
+    method: "POST",
+    uri: "/apis/monitoring.coreos.com/v1/namespaces/keramik-test/podmonitors?",
+    headers: {
+        "content-type": "application/json",
+    },
+    body: {
+      "apiVersion": "monitoring.coreos.com/v1",
+      "kind": "PodMonitor",
+      "metadata": {
+        "name": "ceramic-one"
+      },
+      "spec": {
+        "podMetricsEndpoints": [
+          {
+            "interval": "10s",
+            "path": "/metrics",
+            "targetPort": 9465
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "app": "ceramic"
+          }
+        }
+      }
+    },
+}

--- a/operator/src/network/testdata/pod_monitor_post_otel
+++ b/operator/src/network/testdata/pod_monitor_post_otel
@@ -18,6 +18,11 @@ Request {
             "targetPort": 9464
           }
         ],
+        "podTargetLabels": [
+          "affinity",
+          "scenario",
+          "simulation"
+        ],
         "selector": {
           "matchLabels": {
             "app": "otel"

--- a/operator/src/network/testdata/pod_monitor_post_otel
+++ b/operator/src/network/testdata/pod_monitor_post_otel
@@ -1,0 +1,28 @@
+Request {
+    method: "POST",
+    uri: "/apis/monitoring.coreos.com/v1/namespaces/keramik-test/podmonitors?",
+    headers: {
+        "content-type": "application/json",
+    },
+    body: {
+      "apiVersion": "monitoring.coreos.com/v1",
+      "kind": "PodMonitor",
+      "metadata": {
+        "name": "otel"
+      },
+      "spec": {
+        "podMetricsEndpoints": [
+          {
+            "interval": "10s",
+            "path": "/metrics",
+            "targetPort": 9464
+          }
+        ],
+        "selector": {
+          "matchLabels": {
+            "app": "otel"
+          }
+        }
+      }
+    },
+}


### PR DESCRIPTION
This PR adds automated creation of pod monitoring custom resources that can be used by the Grafana Cloud Agent for Keramik networks.