### PR TITLE
fix: dont restart simulation manager

### DIFF
--- a/operator/src/simulation/manager.rs
+++ b/operator/src/simulation/manager.rs
@@ -131,7 +131,7 @@ pub fn manager_job_spec(config: ManagerConfig) -> JobSpec {
         })
     }
     JobSpec {
-        backoff_limit: Some(4),
+        backoff_limit: Some(1),
         template: PodTemplateSpec {
             metadata: Some(ObjectMeta {
                 labels: Some(BTreeMap::from_iter(vec![(

--- a/operator/src/simulation/testdata/default_stubs/manager_job
+++ b/operator/src/simulation/testdata/default_stubs/manager_job
@@ -16,7 +16,7 @@ Request {
         "ownerReferences": []
       },
       "spec": {
-        "backoffLimit": 4,
+        "backoffLimit": 1,
         "template": {
           "metadata": {
             "labels": {


### PR DESCRIPTION
When checking out the ephemeral usage on ipfs containers during simulation runs, it only occurs on tests that fail to reach the desired rps. We currently fail the job on this condition which causes the simulation-manager to restart.

This restart is unhandled by the scenario and causes worker restarts which appear to impact the ephemeral usage, as we're only seeing it on failed tests, after the scenario completes.

This PR addresses the situation by not restarting a failed simulation-manager job. While not ideal, it's a faster fix than coordinating the manager and workers after a failed job, as it could fail for reasons other than missing the desired rps.

<img width="1070" alt="image" src="https://github.com/3box/keramik/assets/114362991/942f64f8-72bc-48fe-8207-23e7d16e66c6">

