### PR TITLE
feat: record all peer rps in grafana for simulations to calculate avg/min/max 

### DIFF
--- a/runner/src/simulate.rs
+++ b/runner/src/simulate.rs
@@ -489,7 +489,6 @@ impl ScenarioState {
                 let mut errors = vec![];
                 let mut rps_list = vec![];
                 for (name, count) in res {
-                    // the workers are paired to a specific ceramic peer, so we make it look like it lines up nicely here
                     let metric = PeerRequestInfo::new(
                         name.clone(),
                         count as u64,
@@ -595,9 +594,6 @@ impl ScenarioState {
                     Ok(v) => v,
                     Err(e) => return (e, None),
                 };
-
-                info!(?peer_req_cnts, "got peer request counts");
-                info!(?before_metrics, "got before request counts");
 
                 // For now, assume writer and all peers must meet the threshold rate
                 let peer_metrics = match generate_final_request_info(


### PR DESCRIPTION
We capture all peers average RPS over the simulation in `simulation_peer_requests_per_second` with an attribute of `peer`. We still have `simulation_min_peer_requests_per_second`. The motivation is being able to identify if changing something increases node writes, but reduces recon sync. We want a more clear picture of total writes in the scenario.

example includes the `ceramic-new-streams-benchmark` and `recon-event-sync` scenarios:
<img width="1510" alt="image" src="https://github.com/3box/keramik/assets/5317198/b65cf4cd-e08f-4c8f-a947-f027ceb2826a">
