### PR TITLE
feat: add ability to set Ceramic network on simulations

### DIFF
--- a/keramik/src/simulation.md
+++ b/keramik/src/simulation.md
@@ -23,6 +23,7 @@ metadata:
   namespace: keramik-<unique-name>-small
 spec:
   scenario: ceramic-simple
+  network: local
   devMode: true # optional to remove container resource limits and requirements for local benchmarking
   users: 10
   runTime: 4

--- a/operator/src/simulation/controller.rs
+++ b/operator/src/simulation/controller.rs
@@ -173,8 +173,10 @@ async fn reconcile_(
 
     let job_image_config = JobImageConfig::from(spec);
 
+    let network = spec.network.clone().unwrap_or_else(|| "local".to_string());
     let manager_config = ManagerConfig {
         name: status.name.clone(),
+        network: network.clone(),
         scenario: spec.scenario.to_owned(),
         users: spec.users.to_owned(),
         run_time: spec.run_time.to_owned(),
@@ -199,6 +201,7 @@ async fn reconcile_(
             &status,
             simulation.clone(),
             job_image_config.clone(),
+            network,
         )
         .await?;
     }
@@ -317,6 +320,7 @@ async fn apply_n_workers(
     status: &SimulationStatus,
     simulation: Arc<Simulation>,
     job_image_config: JobImageConfig,
+    network: String,
 ) -> Result<(), kube::error::Error> {
     let spec = simulation.spec();
     let orefs = simulation
@@ -327,6 +331,7 @@ async fn apply_n_workers(
     for i in 0..peers {
         let config = WorkerConfig {
             name: status.name.clone(),
+            network: network.clone(),
             scenario: spec.scenario.to_owned(),
             target_peer: i,
             nonce: status.nonce,
@@ -428,7 +433,7 @@ mod tests {
         stub.manager_job.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -45,7 +45,7 @@
+            @@ -49,7 +49,7 @@
                                },
                                {
                                  "name": "SIMULATE_SCENARIO",
@@ -441,7 +446,7 @@ mod tests {
         stub.worker_jobs[0].patch(expect![[r#"
             --- original
             +++ modified
-            @@ -53,7 +53,7 @@
+            @@ -57,7 +57,7 @@
                                },
                                {
                                  "name": "SIMULATE_SCENARIO",
@@ -454,7 +459,7 @@ mod tests {
         stub.worker_jobs[1].patch(expect![[r#"
             --- original
             +++ modified
-            @@ -53,7 +53,7 @@
+            @@ -57,7 +57,7 @@
                                },
                                {
                                  "name": "SIMULATE_SCENARIO",
@@ -484,7 +489,7 @@ mod tests {
         stub.manager_job.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -65,7 +65,7 @@
+            @@ -69,7 +69,7 @@
                                },
                                {
                                  "name": "SIMULATE_USERS",
@@ -514,7 +519,7 @@ mod tests {
         stub.manager_job.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -69,7 +69,7 @@
+            @@ -73,7 +73,7 @@
                                },
                                {
                                  "name": "SIMULATE_RUN_TIME",
@@ -594,7 +599,7 @@ mod tests {
         stub.manager_job.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -45,7 +45,7 @@
+            @@ -49,7 +49,7 @@
                                },
                                {
                                  "name": "SIMULATE_SCENARIO",
@@ -603,7 +608,7 @@ mod tests {
                                },
                                {
                                  "name": "SIMULATE_MANAGER",
-            @@ -89,8 +89,8 @@
+            @@ -93,8 +93,8 @@
                                  }
                                }
                              ],
@@ -618,7 +623,7 @@ mod tests {
         stub.worker_jobs[0].patch(expect![[r#"
             --- original
             +++ modified
-            @@ -53,7 +53,7 @@
+            @@ -57,7 +57,7 @@
                                },
                                {
                                  "name": "SIMULATE_SCENARIO",
@@ -627,7 +632,7 @@ mod tests {
                                },
                                {
                                  "name": "SIMULATE_TARGET_PEER",
-            @@ -85,8 +85,8 @@
+            @@ -89,8 +89,8 @@
                                  }
                                }
                              ],
@@ -642,7 +647,7 @@ mod tests {
         stub.worker_jobs[1].patch(expect![[r#"
             --- original
             +++ modified
-            @@ -53,7 +53,7 @@
+            @@ -57,7 +57,7 @@
                                },
                                {
                                  "name": "SIMULATE_SCENARIO",
@@ -651,7 +656,7 @@ mod tests {
                                },
                                {
                                  "name": "SIMULATE_TARGET_PEER",
-            @@ -85,8 +85,8 @@
+            @@ -89,8 +89,8 @@
                                  }
                                }
                              ],
@@ -683,7 +688,7 @@ mod tests {
         stub.manager_job.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -87,6 +87,10 @@
+            @@ -91,6 +91,10 @@
                                      "name": "ceramic-admin"
                                    }
                                  }
@@ -698,7 +703,7 @@ mod tests {
         stub.worker_jobs[0].patch(expect![[r#"
             --- original
             +++ modified
-            @@ -83,6 +83,10 @@
+            @@ -87,6 +87,10 @@
                                      "name": "ceramic-admin"
                                    }
                                  }
@@ -713,7 +718,7 @@ mod tests {
         stub.worker_jobs[1].patch(expect![[r#"
             --- original
             +++ modified
-            @@ -83,6 +83,10 @@
+            @@ -87,6 +87,10 @@
                                      "name": "ceramic-admin"
                                    }
                                  }
@@ -746,7 +751,7 @@ mod tests {
         stub.manager_job.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -87,6 +87,10 @@
+            @@ -91,6 +91,10 @@
                                      "name": "ceramic-admin"
                                    }
                                  }

--- a/operator/src/simulation/manager.rs
+++ b/operator/src/simulation/manager.rs
@@ -30,6 +30,7 @@ pub fn service_spec() -> ServiceSpec {
 // ManagerConfig defines which properties of the JobSpec can be customized.
 pub struct ManagerConfig {
     pub name: String,
+    pub network: String,
     pub scenario: String,
     pub users: u32,
     pub run_time: u32,
@@ -54,6 +55,11 @@ pub fn manager_job_spec(config: ManagerConfig) -> JobSpec {
         EnvVar {
             name: "SIMULATE_NAME".to_owned(),
             value: Some(config.name.to_owned()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "SIMULATE_NETWORK".to_owned(),
+            value: Some(config.network.to_owned()),
             ..Default::default()
         },
         EnvVar {

--- a/operator/src/simulation/spec.rs
+++ b/operator/src/simulation/spec.rs
@@ -17,6 +17,16 @@ use serde::{Deserialize, Serialize};
 pub struct SimulationSpec {
     /// Simulation runner scenario
     pub scenario: String,
+    /// Name of the network to use.
+    /// One of:
+    ///   - mainnet:      Production network
+    ///   - testnet-clay: Test network
+    ///   - dev-unstable: Developement network
+    ///   - local:        Local network, always uses 0 for the local id
+    ///   - in-memory:    Singleton network in memory
+    ///
+    ///   Defaults to local
+    pub network: Option<String>,
     /// Number of users
     pub users: u32,
     /// Time in minutes to run the simulation

--- a/operator/src/simulation/testdata/default_stubs/manager_job
+++ b/operator/src/simulation/testdata/default_stubs/manager_job
@@ -44,6 +44,10 @@ Request {
                     "value": "sim-test"
                   },
                   {
+                    "name": "SIMULATE_NETWORK",
+                    "value": "local"
+                  },
+                  {
                     "name": "SIMULATE_SCENARIO",
                     "value": ""
                   },

--- a/operator/src/simulation/testdata/default_stubs/worker_job_0
+++ b/operator/src/simulation/testdata/default_stubs/worker_job_0
@@ -48,6 +48,10 @@ Request {
                     "value": "1"
                   },
                   {
+                    "name": "SIMULATE_NETWORK",
+                    "value": "local"
+                  },
+                  {
                     "name": "SIMULATE_NAME",
                     "value": "sim-test"
                   },

--- a/operator/src/simulation/testdata/default_stubs/worker_job_1
+++ b/operator/src/simulation/testdata/default_stubs/worker_job_1
@@ -48,6 +48,10 @@ Request {
                     "value": "1"
                   },
                   {
+                    "name": "SIMULATE_NETWORK",
+                    "value": "local"
+                  },
+                  {
                     "name": "SIMULATE_NAME",
                     "value": "sim-test"
                   },

--- a/operator/src/simulation/testdata/worker_job_2
+++ b/operator/src/simulation/testdata/worker_job_2
@@ -48,6 +48,10 @@ Request {
                     "value": "1"
                   },
                   {
+                    "name": "SIMULATE_NETWORK",
+                    "value": "local"
+                  },
+                  {
                     "name": "SIMULATE_NAME",
                     "value": "sim-test"
                   },

--- a/operator/src/simulation/worker.rs
+++ b/operator/src/simulation/worker.rs
@@ -15,6 +15,7 @@ use crate::{network::PEERS_CONFIG_MAP_NAME, simulation::job::JobImageConfig};
 // WorkerConfig defines which properties of the JobSpec can be customized.
 pub struct WorkerConfig {
     pub name: String,
+    pub network: String,
     pub scenario: String,
     pub target_peer: u32,
     pub nonce: u32,
@@ -42,6 +43,11 @@ pub fn worker_job_spec(config: WorkerConfig) -> JobSpec {
         EnvVar {
             name: "RUST_BACKTRACE".to_owned(),
             value: Some("1".to_owned()),
+            ..Default::default()
+        },
+        EnvVar {
+            name: "SIMULATE_NETWORK".to_owned(),
+            value: Some(config.network.to_owned()),
             ..Default::default()
         },
         EnvVar {

--- a/runner/src/simulate.rs
+++ b/runner/src/simulate.rs
@@ -104,7 +104,7 @@ pub enum NetworkOpt {
 
 impl std::fmt::Display for NetworkOpt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", Network::from(self.clone()).name())
+        write!(f, "{}", Network::from(*self).name())
     }
 }
 


### PR DESCRIPTION
Prior to this change the simulations would always assume a Ceramic network of local 0. Now it is configurable.

NOTE: This is not ideal as it requires that both the network and the simulation are configured with the same Ceramic network id. However once we make the changes to remove the EventID from the Ceramic API this will no longer be necessary and can be removed. 