### PR TITLE
feat: add init image name for ceramic

### DIFF
--- a/operator/src/network/ceramic.rs
+++ b/operator/src/network/ceramic.rs
@@ -135,6 +135,7 @@ pub fn service_spec() -> ServiceSpec {
 pub struct CeramicConfig {
     pub weight: i32,
     pub init_config_map: String,
+    pub init_image_name: String,
     pub image: String,
     pub image_pull_policy: String,
     pub ipfs: IpfsConfig,
@@ -254,6 +255,7 @@ impl Default for CeramicConfig {
             init_config_map: INIT_CONFIG_MAP_NAME.to_owned(),
             image: "ceramicnetwork/composedb:latest".to_owned(),
             image_pull_policy: "Always".to_owned(),
+            init_image_name: "ceramicnetwork/composedb-cli:latestt".to_owned(),
             ipfs: IpfsConfig::default(),
             resource_limits: ResourceLimitsConfig {
                 cpu: Some(Quantity("250m".to_owned())),
@@ -292,6 +294,7 @@ impl From<CeramicSpec> for CeramicConfig {
         Self {
             weight: value.weight.unwrap_or(default.weight),
             init_config_map: value.init_config_map.unwrap_or(default.init_config_map),
+            init_image_name: value.init_image_name.unwrap_or(default.init_image_name),
             image: value.image.unwrap_or(default.image),
             image_pull_policy: value.image_pull_policy.unwrap_or(default.image_pull_policy),
             ipfs: value.ipfs.map(Into::into).unwrap_or(default.ipfs),

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -146,6 +146,8 @@ pub struct CeramicSpec {
     pub weight: Option<i32>,
     /// Name of a config map with a ceramic-init.sh script that runs as an initialization step.
     pub init_config_map: Option<String>,
+    /// Name of the image to initialize the ceramic container.
+    pub init_image_name: Option<String>,
     /// Image of the ceramic container.
     pub image: Option<String>,
     /// Pull policy for the ceramic container image.


### PR DESCRIPTION
Currently we're using the same image for the ceramic service init container that runs the actual workload.

We can't guarantee the composedb cli is available in the image for the private-key -> did transform (it's not by default).

This PR uses the new `"ceramicnetwork/composedb-cli:latest` image which has the required tooling for the init container and exposes it for other init needs.

