### PR TITLE
feat: add debug mode to network

### DIFF
--- a/operator/src/network/ceramic.rs
+++ b/operator/src/network/ceramic.rs
@@ -33,6 +33,8 @@ use crate::{
     },
 };
 
+use super::debug_mode_security_context;
+
 pub fn config_maps(
     info: &CeramicInfo,
     config: &CeramicConfig,
@@ -173,6 +175,7 @@ pub struct NetworkConfig {
     pub eth_rpc_url: String,
     pub cas_api_url: String,
     pub node_affinity_config: NodeAffinityConfig,
+    pub debug_mode: bool,
 }
 
 impl Default for NetworkConfig {
@@ -183,6 +186,7 @@ impl Default for NetworkConfig {
             eth_rpc_url: format!("http://{GANACHE_SERVICE_NAME}:8545"),
             cas_api_url: format!("http://{CAS_SERVICE_NAME}:8081"),
             node_affinity_config: NodeAffinityConfig::default(),
+            debug_mode: false,
         }
     }
 }
@@ -199,6 +203,7 @@ impl From<&NetworkSpec> for NetworkConfig {
             eth_rpc_url: value.eth_rpc_url.to_owned().unwrap_or(default.eth_rpc_url),
             cas_api_url: value.cas_api_url.to_owned().unwrap_or(default.cas_api_url),
             node_affinity_config: value.into(),
+            debug_mode: value.debug_mode.unwrap_or(default.debug_mode),
         }
     }
 }
@@ -570,6 +575,10 @@ pub fn stateful_set_spec(ns: &str, bundle: &CeramicBundle<'_>) -> StatefulSetSpe
                                     ..Default::default()
                                 },
                             ]),
+                            security_context: bundle
+                                .net_config
+                                .debug_mode
+                                .then(debug_mode_security_context),
                             ..Default::default()
                         },
                         Container {

--- a/operator/src/network/mod.rs
+++ b/operator/src/network/mod.rs
@@ -2,6 +2,7 @@
 
 // Export all spec types
 mod spec;
+use k8s_openapi::api::core::v1::{Capabilities, SecurityContext};
 pub use spec::*;
 
 // All other mods are behind the controller flag to keep the deps to a minimum
@@ -37,3 +38,16 @@ pub use crate::utils::Context;
 
 #[cfg(feature = "controller")]
 pub use controller::{run, PEERS_CONFIG_MAP_NAME};
+
+// Construct a SecurityContext for the debug mode spec setting.
+// To be used by any containers that we might need to debug (i.e. containers running software we
+// produce).
+fn debug_mode_security_context() -> SecurityContext {
+    SecurityContext {
+        capabilities: Some(Capabilities {
+            add: Some(vec!["SYS_PTRACE".to_string()]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}

--- a/operator/src/network/mod.rs
+++ b/operator/src/network/mod.rs
@@ -2,7 +2,6 @@
 
 // Export all spec types
 mod spec;
-use k8s_openapi::api::core::v1::{Capabilities, SecurityContext};
 pub use spec::*;
 
 // All other mods are behind the controller flag to keep the deps to a minimum
@@ -42,9 +41,10 @@ pub use controller::{run, PEERS_CONFIG_MAP_NAME};
 // Construct a SecurityContext for the debug mode spec setting.
 // To be used by any containers that we might need to debug (i.e. containers running software we
 // produce).
-fn debug_mode_security_context() -> SecurityContext {
-    SecurityContext {
-        capabilities: Some(Capabilities {
+#[cfg(feature = "controller")]
+fn debug_mode_security_context() -> k8s_openapi::api::core::v1::SecurityContext {
+    k8s_openapi::api::core::v1::SecurityContext {
+        capabilities: Some(k8s_openapi::api::core::v1::Capabilities {
             add: Some(vec!["SYS_PTRACE".to_string()]),
             ..Default::default()
         }),

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -50,6 +50,11 @@ pub struct NetworkSpec {
     /// explicitly overridden by the spec. This allows deploying the network on a smaller machine,
     /// as well as running every container with unlimited resources.
     pub dev_mode: Option<bool>,
+    /// Enable debug mode for the network. This will add capabilities to containers to enable
+    /// process tracing and other debug related features.
+    /// Generally do NOT run debug_mode on production infrastructure as it has weaker security
+    /// properties.
+    pub debug_mode: Option<bool>,
     /// Enable monitoring resources to be deployed into the network.
     pub monitoring: Option<MonitoringSpec>,
     /// A list of node selector terms. These node select terms will be applied to all pods in the network.


### PR DESCRIPTION
This creates a new debug mode flag on the network spec that enables security contexts and tokio console as appropriate.

This will require we redeploy the crds to the clusters but is a backwards compatible change.