### PR TITLE
Feature/cas load test scenario

### DIFF
--- a/1
+++ b/1
@@ -1,0 +1,26 @@
+---
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: ceramic-anchoring-benchmark
+spec:
+  replicas: 13
+  bootstrap:
+    image: "samika98/runner:test13"
+    imagePullPolicy: Always
+  ceramic:
+    - env:
+        CERAMIC_RECON_MODE: "true"
+      image: "ceramicnetwork/js-ceramic:develop"
+      imagePullPolicy: Always # Ensures the image is always pulled before starting the pod
+      ipfs:
+        rust:
+          env:
+            CERAMIC_ONE_RECON: "true"
+  casApiUrl: https://cas-dev.3boxlabs.com
+  networkType: dev-unstable
+  privateKeySecret: ceramic-v4-dev
+  ethRpcUrl: ""
+
+  monitoring:
+    namespaced: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2796,8 +2796,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.21.7",
  "ceramic-core 0.9.0 (git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main)",
  "ceramic-http-client",
+ "chrono",
  "clap",
  "did-method-key",
  "ed25519-dalek",
@@ -2819,6 +2821,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -3141,6 +3144,7 @@ dependencies = [
  "core2",
  "multibase 0.9.1",
  "multihash 0.18.1",
+ "serde",
  "thiserror",
 ]
 
@@ -6365,6 +6369,15 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/local-scripts/build-runner-gke.sh
+++ b/local-scripts/build-runner-gke.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Build and tag Docker image
+# docker buildx build --load -t samika98/runner:dev1 --target runner --platform linux/amd64 .
+
+# # Push Docker image
+# docker push samika98/runner:dev1
+
+# Delete the existing Keramik network
+kubectl delete networks.keramik.3box.io keramik-samika-perftest
+
+# Wait for 2 minutes
+echo "Waiting for 1 minutes..."
+sleep 60
+
+# Apply the first configuration file
+kubectl apply -f 1
+
+# Check if steps 6 and 7 should be skipped
+# if [ "$1" != "ss" ]; then
+#     echo "Waiting for the network to come up (approximately 5 minutes)..."
+#     # Wait for about 5 minutes for the network to come up
+#     sleep 300
+
+#     # Apply the ceramic-anchoring-benchmark configuration
+#     kubectl apply -f ceramic-anchoring-benchmark.yaml
+# else
+#     echo "Skipping steps 6 and 7 as requested."
+# fi

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -4,7 +4,6 @@ description = "Utility binary for performing various jobs to simulate Ceramic ne
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow.workspace = true
@@ -18,7 +17,7 @@ did-method-key = "0.2"
 goose = { version = "0.16", features = ["gaggle"] }
 hex.workspace = true
 keramik-common = { workspace = true, features = ["telemetry", "tokio-console"] }
-libipld = "0.16.0"
+libipld = { version = "0.16.0", features = ["serde-codec"] }
 multihash.workspace = true
 opentelemetry.workspace = true
 rand = "0.8.5"
@@ -34,7 +33,6 @@ multibase.workspace = true
 base64 = "0.21.5"
 uuid = { version = "1.6.1", features = ["v4"] }
 chrono = "0.4.31"
-
 ed25519-dalek = "2.1"
 
 [dev-dependencies]

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -34,7 +34,6 @@ multibase.workspace = true
 base64 = "0.21.5"
 uuid = { version = "1.6.1", features = ["v4"] }
 chrono = "0.4.31"
-
 ed25519-dalek = "2.1"
 
 [dev-dependencies]

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -24,13 +24,16 @@ opentelemetry.workspace = true
 rand = "0.8.5"
 redis = { version = "0.24", features = ["tokio-comp"] }
 reqwest.workspace = true
+serde = { version = "1.0", features = ["derive"] } 
 schemars.workspace = true
-serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 multibase.workspace = true
+base64 = "0.21.5"
+uuid = { version = "1.6.1", features = ["v4"] }
+chrono = "0.4.31"
 
 ed25519-dalek = "2.1"
 

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -24,6 +24,7 @@ rand = "0.8.5"
 redis = { version = "0.24", features = ["tokio-comp"] }
 reqwest.workspace = true
 serde = { version = "1.0", features = ["derive"] } 
+serde = { version = "1.0", features = ["derive"] } 
 schemars.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
@@ -33,6 +34,7 @@ multibase.workspace = true
 base64 = "0.21.5"
 uuid = { version = "1.6.1", features = ["v4"] }
 chrono = "0.4.31"
+
 ed25519-dalek = "2.1"
 
 [dev-dependencies]

--- a/runner/src/scenario/ceramic/anchor.rs
+++ b/runner/src/scenario/ceramic/anchor.rs
@@ -1,0 +1,182 @@
+use anyhow::Result;
+use ceramic_core::{Cid, DidDocument, JwkSigner, Jws, StreamId, StreamIdType};
+use chrono::Utc;
+use goose::prelude::*;
+use iroh_car::{CarHeader, CarWriter};
+use libipld::{cbor::DagCborCodec, ipld, prelude::Codec, Ipld, IpldCodec};
+use multihash::{Code::Sha2_256, MultihashDigest};
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use redis::AsyncCommands;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use std::{collections::BTreeMap, sync::Arc};
+use uuid::Uuid;
+
+use crate::scenario::{ceramic::model_instance::CeramicModelInstanceTestUser, get_redis_client};
+
+#[derive(Serialize, Deserialize)]
+struct CasAuthPayload {
+    url: String,
+    nonce: String,
+    digest: String,
+}
+
+async fn auth_header(url: String, controller: String, digest: Cid) -> Result<String> {
+    let auth_payload = CasAuthPayload {
+        url,
+        nonce: Uuid::new_v4().to_string(),
+        digest: digest.to_string(),
+    };
+
+    let node_private_key = std::env::var("NODE_PRIVATE_KEY").unwrap_or_else(|_| "your_default_private_key".to_string());
+    let signer = JwkSigner::new(DidDocument::new(controller.as_str()), &node_private_key)
+        .await
+        .unwrap();
+    let auth_jws = Jws::for_data(&signer, &auth_payload).await?;
+    let (sig, protected) = auth_jws
+        .signatures
+        .first()
+        .and_then(|sig| sig.protected.as_ref().map(|p| (&sig.signature, p)))
+        .unwrap();
+    Ok(format!("Bearer {}.{}.{}", protected, auth_jws.payload, sig))
+}
+
+pub async fn stream_tip_car(
+    stream_id: StreamId,
+    genesis_cid: Cid,
+    genesis_block: Vec<u8>,
+    tip_cid: Cid,
+    tip_block: Vec<u8>,
+) -> Result<(Cid, Vec<u8>)> {
+    let root_block = ipld!({
+        "timestamp": Utc::now().to_rfc3339(),
+        "streamId": stream_id.to_vec()?,
+        "tip": genesis_cid,
+    });
+    // let ipld_map: BTreeMap<String, Ipld> = libipld::serde::from_ipld(root_block)?;
+    let ipld_bytes = DagCborCodec.encode(&root_block)?;
+    let root_cid = Cid::new_v1(IpldCodec::DagCbor.into(), Sha2_256.digest(&ipld_bytes));
+    // let ipld_bytes = DagCborCodec.encode(&ipld_map)?;
+    // let root_cid = Cid::new_v1(IpldCodec::DagCbor.into(), Sha2_256.digest(&ipld_bytes));
+    let car_header = CarHeader::new_v1(vec![root_cid]);
+    let mut car_writer = CarWriter::new(car_header, Vec::new());
+    car_writer.write(root_cid, ipld_bytes).await.unwrap();
+    car_writer.write(genesis_cid, genesis_block.clone()).await.unwrap();
+    car_writer.write(tip_cid, tip_block).await.unwrap();
+    Ok((root_cid, car_writer.finish().await.unwrap().to_vec()))
+}
+
+pub async fn create_anchor_request_on_cas(
+    user: &mut GooseUser,
+    cas_service_url: &str,
+    auth_token: &str,
+    tx_name: &str,
+) -> TransactionResult {
+    let user_data = CeramicModelInstanceTestUser::user_data(user).to_owned();
+
+    let (stream_id, genesis_cid, genesis_block) =
+        create_stream(StreamIdType::Tile, user_data.user_info.did.to_string(), true).unwrap();
+
+    let (root_cid, car_bytes) = stream_tip_car(
+        stream_id.clone(),
+        genesis_cid,
+        genesis_block.clone(),
+        genesis_cid,
+        genesis_block,
+    )
+    .await
+    .unwrap();
+
+
+    let name = format!("create_anchor_request_{}", tx_name);
+
+    let goose_request = GooseRequest::builder()
+        .name(name.as_str())
+        .method(GooseMethod::Post)
+        .set_request_builder(Client::new()
+            .post(cas_service_url)
+            .header("Authorization", auth_token)
+            .header("Content-Type", "application/vnd.ipld.car")
+            .body(car_bytes))
+        .expect_status_code(200)
+        .build();
+
+    let _response = user.request(goose_request).await?;
+
+    let mut conn = user_data.redis_cli().get_async_connection().await.unwrap();
+    let _: () = conn.sadd("anchor_requests", stream_id.to_string()).await.unwrap();
+
+    Ok(())
+}
+
+pub async fn cas_benchmark() -> Result<Scenario, GooseError> {
+    let redis_cli = get_redis_client().await.unwrap();
+    let multiplexed_conn = redis_cli.get_multiplexed_tokio_connection().await.unwrap();
+    let shared_conn = Arc::new(Mutex::new(multiplexed_conn));
+
+    let cas_service_url = std::env::var("CAS_SERVICE_URL").unwrap_or_else(|_| "http://localhost:8081/api/v0/requests".to_string());
+    let auth_token = std::env::var("CAS_AUTH_TOKEN").unwrap_or_else(|_| "your_default_auth_token".to_string());
+
+    let create_anchor_request = Transaction::new(Arc::new(move |user| {
+        Box::pin(create_anchor_request_on_cas(
+            user,
+            &cas_service_url,
+            &auth_token,
+            "create_anchor_request",
+        ))
+    }))
+    .set_name("create_anchor_request");
+
+    Ok(scenario!("CeramicCasBenchmark")
+        .register_transaction(create_anchor_request))
+}
+
+/// Create a new Ceramic stream
+pub fn create_stream(
+    stream_type: StreamIdType,
+    controller: Option<String>,
+    unique: bool,
+) -> Result<(StreamId, Cid, Vec<u8>)> {
+    let controller = controller.unwrap_or_else(|| {
+        thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(32)
+            .map(char::from)
+            .collect()
+    });
+    let genesis_commit = if unique {
+        ipld!({
+            "header": {
+                "unique": stream_unique_header(),
+                "controllers": [controller]
+            }
+        })
+    } else {
+        ipld!({
+            "header": {
+                "controllers": [controller]
+            }
+        })
+    };
+    // Deserialize the genesis commit, encode it as CBOR, and compute the CID.
+    let ipld_map: BTreeMap<String, Ipld> = libipld::serde::from_ipld(genesis_commit)?;
+    let ipld_bytes = DagCborCodec.encode(&ipld_map)?;
+    let genesis_cid = Cid::new_v1(IpldCodec::DagCbor.into(), Sha2_256.digest(&ipld_bytes));
+    Ok((
+        StreamId {
+            r#type: stream_type,
+            cid: genesis_cid,
+        },
+        genesis_cid,
+        ipld_bytes,
+    ))
+}
+
+// fn convert_type(value: StreamType) -> StreamIdType {
+//     match value {
+//         StreamType::Tile => StreamIdType::Tile,
+//         StreamType::Model => StreamIdType::Model,
+//         StreamType::Document => StreamIdType::ModelInstanceDocument,
+//     }
+// }

--- a/runner/src/scenario/ceramic/mod.rs
+++ b/runner/src/scenario/ceramic/mod.rs
@@ -1,9 +1,9 @@
+pub mod anchor;
 pub mod model_instance;
 mod models;
 pub mod new_streams;
 pub mod query;
 pub mod simple;
-pub mod anchor;
 pub mod util;
 pub mod write_only;
 
@@ -68,7 +68,10 @@ impl Credentials {
         let doc: DidDocument = DocumentBuilder::default()
             .id(did)
             .build()
-            .map_err(|e| anyhow::anyhow!("failed to build DID document: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("failed to build DID document: {}", e))
+            .map(|core_doc| {
+                ceramic_http_client::ceramic_event::DidDocument::new(core_doc.id.as_str())
+            })?;
         tracing::debug!("Generated DID: {:?}", doc);
         Ok(doc)
     }
@@ -174,7 +177,10 @@ impl From<Scenario> for CeramicScenarioParameters {
                 number_of_documents: 3,
                 store_mids: false,
             },
-            Scenario::IpfsRpc | Scenario::ReconEventSync | Scenario::ReconEventKeySync | Scenario::CASBenchmark => {
+            Scenario::IpfsRpc
+            | Scenario::ReconEventSync
+            | Scenario::ReconEventKeySync
+            | Scenario::CASBenchmark => {
                 panic!("Not supported for non ceramic scenarios")
             }
             Scenario::CeramicAnchoringBenchmark => Self {

--- a/runner/src/scenario/ceramic/mod.rs
+++ b/runner/src/scenario/ceramic/mod.rs
@@ -3,6 +3,7 @@ mod models;
 pub mod new_streams;
 pub mod query;
 pub mod simple;
+pub mod anchor;
 pub mod util;
 pub mod write_only;
 
@@ -173,7 +174,7 @@ impl From<Scenario> for CeramicScenarioParameters {
                 number_of_documents: 3,
                 store_mids: false,
             },
-            Scenario::IpfsRpc | Scenario::ReconEventSync | Scenario::ReconEventKeySync => {
+            Scenario::IpfsRpc | Scenario::ReconEventSync | Scenario::ReconEventKeySync | Scenario::CASBenchmark => {
                 panic!("Not supported for non ceramic scenarios")
             }
             Scenario::CeramicAnchoringBenchmark => Self {

--- a/runner/src/scenario/ceramic/model_instance.rs
+++ b/runner/src/scenario/ceramic/model_instance.rs
@@ -536,7 +536,7 @@ impl ModelInstanceRequests {
             .create_query_request(model_id, filter, Pagination::default())
             .await
             .unwrap();
-        let goose = user
+        let goose: goose::goose::GooseResponse = user
             .request(
                 GooseRequest::builder()
                     .name("query_model")

--- a/runner/src/scenario/ceramic/new_streams.rs
+++ b/runner/src/scenario/ceramic/new_streams.rs
@@ -145,7 +145,7 @@ pub async fn small_large_scenario(
         let conn_clone = instantiate_small_model_conn.clone();
         Box::pin(async move {
             let mut conn = conn_clone.lock().await;
-            instantiate_small_model(user, params.store_mids, &mut *conn).await
+            instantiate_small_model(user, params.store_mids, &mut conn).await
         })
     }))
     .set_name("instantiate_small_model");
@@ -155,7 +155,7 @@ pub async fn small_large_scenario(
         let conn_clone = instantiate_large_model_conn.clone();
         Box::pin(async move {
             let mut conn = conn_clone.lock().await;
-            instantiate_large_model(user, params.store_mids, &mut *conn).await
+            instantiate_large_model(user, params.store_mids, &mut conn).await
         })
     }))
     .set_name("instantiate_large_model");
@@ -222,10 +222,7 @@ async fn instantiate_small_model(
     .await?;
     if store_in_redis {
         let stream_id_string = response.to_string();
-        let _: () = conn
-            .sadd(format!("anchor_mids"), stream_id_string)
-            .await
-            .unwrap();
+        let _: () = conn.sadd("anchor_mids", stream_id_string).await.unwrap();
     }
     Ok(())
 }
@@ -246,10 +243,7 @@ async fn instantiate_large_model(
     .await?;
     if store_in_redis {
         let stream_id_string = response.to_string();
-        let _: () = conn
-            .sadd(format!("anchor_mids"), stream_id_string)
-            .await
-            .unwrap();
+        let _: () = conn.sadd("anchor_mids", stream_id_string).await.unwrap();
     }
     Ok(())
 }

--- a/runner/src/simulate.rs
+++ b/runner/src/simulate.rs
@@ -504,6 +504,7 @@ impl ScenarioState {
             | Scenario::CeramicWriteOnly
             | Scenario::CeramicNewStreams
             | Scenario::CeramicQuery
+            | Scenario::CASBenchmark
             | Scenario::CeramicModelReuse => (CommandResult::Success, None),
             Scenario::CeramicNewStreamsBenchmark => {
                 let res =
@@ -688,6 +689,7 @@ impl ScenarioState {
         sleep(wait_duration).await;
 
         // Pick a peer at random
+        let peer = self.peers.first().unwrap();
         let peer = self.peers.first().unwrap();
 
         let ids = self.get_set_from_redis(ANCHOR_REQUEST_MIDS_KEY).await?;

--- a/runner/src/simulate.rs
+++ b/runner/src/simulate.rs
@@ -504,7 +504,6 @@ impl ScenarioState {
             | Scenario::CeramicWriteOnly
             | Scenario::CeramicNewStreams
             | Scenario::CeramicQuery
-            | Scenario::CASBenchmark
             | Scenario::CeramicModelReuse => (CommandResult::Success, None),
             Scenario::CeramicNewStreamsBenchmark => {
                 let res =

--- a/runner/src/simulate.rs
+++ b/runner/src/simulate.rs
@@ -29,10 +29,6 @@ use crate::{
 // FIXME: is it worth attaching metrics to the peer info?
 const IPFS_SERVICE_METRICS_PORT: &str = "9465";
 const EVENT_SYNC_METRIC_NAME: &str = "ceramic_store_key_insert_count_total";
-const PROM_METRICS_PATH: &str = "9464/metrics";
-const CERAMIC_CAS_SUCCESS_METRIC_NAME: &str = "js_ceramic_cas_request_completed_total";
-const CERAMIC_CAS_FAILED_METRIC_NAME: &str = "js_ceramic_cas_request_failed_total";
-const CERAMIC_CAS_REQUESTED_METRIC_NAME: &str = "js_ceramic_cas_request_created_total";
 const ANCHOR_REQUEST_MIDS_KEY: &str = "anchor_mids";
 const CAS_ANCHOR_REQUEST_KEY: &str = "anchor_requests";
 
@@ -232,21 +228,14 @@ struct PeerRequestMetricInfo {
     pub name: String,
     pub count: u64,
     pub runtime: Option<u64>,
-    pub metric_type: Option<String>,
 }
 
 impl PeerRequestMetricInfo {
-    pub fn new(
-        name: String,
-        count: u64,
-        runtime: Option<u64>,
-        metric_type: Option<String>,
-    ) -> Self {
+    pub fn new(name: String, count: u64, runtime: Option<u64>) -> Self {
         Self {
             name,
             count,
             runtime,
-            metric_type,
         }
     }
 
@@ -306,7 +295,6 @@ fn final_peer_req_metric_info(
                     before.name.to_owned(),
                     current.count - before.count,
                     Some(run_time_seconds),
-                    None,
                 ))
             } else {
                 Err(anyhow!(
@@ -455,13 +443,11 @@ impl ScenarioState {
                             parse_base_url_to_pod(&addr)?,
                             m,
                             None,
-                            None,
                         ));
                     } else {
                         results.push(PeerRequestMetricInfo::new(
                             parse_base_url_to_pod(&addr)?,
                             0, // Use 0 as the count if the metric is not found
-                            None,
                             None,
                         ));
                     }
@@ -472,31 +458,6 @@ impl ScenarioState {
             }
         }
         Ok(results)
-    }
-
-    async fn combine_metrics(
-        &self,
-        metric_names: Vec<String>,
-        metric_types: &[&str],
-        metrics_path: &str,
-    ) -> Result<Vec<PeerRequestMetricInfo>> {
-        let mut combined_metrics = Vec::new();
-
-        for (metric_name, metric_type) in metric_names.into_iter().zip(metric_types.iter()) {
-            let metrics = self
-                .get_peers_counter_metric(&metric_name, metrics_path)
-                .await?;
-
-            let metrics_with_type = metrics
-                .into_iter()
-                .map(|metric| PeerRequestMetricInfo {
-                    metric_type: Some(metric_type.to_string()),
-                    ..metric
-                })
-                .collect::<Vec<_>>();
-            combined_metrics.extend(metrics_with_type);
-        }
-        Ok(combined_metrics)
     }
 
     async fn collect_before_metrics(&mut self) -> Result<()> {
@@ -511,8 +472,8 @@ impl ScenarioState {
                 | Scenario::CeramicQuery
                 | Scenario::CASBenchmark
                 | Scenario::CeramicModelReuse => Ok(()),
-                Scenario::CeramicNewStreamsBenchmark => {
-                    // we collect things in the scenario and use redis to propagate the metrics to the manager
+                Scenario::CeramicAnchoringBenchmark | Scenario::CeramicNewStreamsBenchmark => {
+                    // we collect things in the scenario and use redis to decide success/failure of the test
                     Ok(())
                 }
                 Scenario::ReconEventSync | Scenario::ReconEventKeySync => {
@@ -521,16 +482,6 @@ impl ScenarioState {
                         .await?;
 
                     self.before_metrics = Some(peers);
-                    Ok(())
-                }
-                Scenario::CeramicAnchoringBenchmark => {
-                    self.before_metrics = Some(
-                        self.get_peers_counter_metric(
-                            CERAMIC_CAS_REQUESTED_METRIC_NAME,
-                            PROM_METRICS_PATH,
-                        )
-                        .await?,
-                    );
                     Ok(())
                 }
             }
@@ -572,7 +523,6 @@ impl ScenarioState {
                         name.clone(),
                         count as u64,
                         Some(metrics.duration as u64),
-                        None,
                     );
                     let rps = metric.rps();
                     rps_list.push(metric);
@@ -765,7 +715,6 @@ impl ScenarioState {
         self.remove_stream_from_redis(ANCHOR_REQUEST_MIDS_KEY, ids)
             .await?;
 
-        // TODO_3164_5 : Report these counts to Graphana : open telemetry emit how its done in MetricsInner
 
         // Log the counts
         info!("Not requested count: {:2}", not_requested_count);
@@ -773,55 +722,6 @@ impl ScenarioState {
         info!("Pending count: {:2}", pending_count);
         info!("Failed count: {:2}", failed_count);
 
-        // TODO_3164_6 : Logic to caluclate RPS, remove it if not needed
-        let after_metrics = self
-            .combine_metrics(
-                vec![
-                    CERAMIC_CAS_SUCCESS_METRIC_NAME.to_string(),
-                    CERAMIC_CAS_FAILED_METRIC_NAME.to_string(),
-                ],
-                &["success", "failure"],
-                PROM_METRICS_PATH,
-            )
-            .await?;
-        let before_metrics = self.before_metrics.as_ref().unwrap();
-
-        // Calculate success and failure counts
-        let (success_count, failure_count): (u64, u64) = after_metrics
-            .iter()
-            .zip(before_metrics)
-            .fold((0, 0), |(success_acc, failure_acc), (after, before)| {
-                let success_diff = if after.metric_type == Some("success".to_string()) {
-                    after.count - before.count
-                } else {
-                    0
-                };
-                let failure_diff = if after.metric_type == Some("failure".to_string()) {
-                    after.count - before.count
-                } else {
-                    0
-                };
-                (success_acc + success_diff, failure_acc + failure_diff)
-            });
-
-        // Calculate total runtime seconds
-        let total_runtime_seconds: u64 = after_metrics
-            .iter()
-            .map(|metric| metric.runtime.unwrap_or(0))
-            .sum();
-
-        // Calculate success and failure RPS
-        let success_rps = success_count as f64 / total_runtime_seconds as f64;
-        let failure_rps = failure_count as f64 / total_runtime_seconds as f64;
-
-        // Log success and failure counts
-        info!("Total runtime is: {}", total_runtime_seconds);
-        info!("Success count: {}", success_count);
-        // Log success and failure RPS
-        info!("Success RPS: {:.2}", success_rps);
-        info!("Failure RPS: {:.2}", failure_rps);
-
-        // Determine success based on the anchored_count
         if failed_count > 0 {
             Ok((
                 CommandResult::Failure(anyhow!("Failed count is greater than 0")),
@@ -831,6 +731,7 @@ impl ScenarioState {
             info!("Anchored count is : {}", anchored_count);
             Ok((CommandResult::Success, None))
         }
+        // TODO_3164_2 : Report these counts to Graphana
     }
 
     /// Removed from `validate_scenario_success` to make testing easier as constructing the GooseMetrics appropriately is difficult

--- a/runner/src/simulate.rs
+++ b/runner/src/simulate.rs
@@ -33,6 +33,7 @@ const PROM_METRICS_PATH: &str = "9464/metrics";
 const CERAMIC_CAS_SUCCESS_METRIC_NAME: &str = "js_ceramic_cas_request_completed_total";
 const CERAMIC_CAS_FAILED_METRIC_NAME: &str = "js_ceramic_cas_request_failed_total";
 const CERAMIC_CAS_REQUESTED_METRIC_NAME: &str = "js_ceramic_cas_request_created_total";
+const ANCHOR_REQUEST_MIDS_KEY: &str = "anchor_mids";
 
 /// Options to Simulate command
 #[derive(Args, Debug)]
@@ -131,6 +132,12 @@ pub enum Scenario {
     // This is a benchmark scenario for e2e testing, simliar to the recon event sync scenario,
     // but covering using js-ceramic rather than talking directly to the ipfs API.
     CeramicAnchoringBenchmark,
+
+    // Scenario that creates model instance documents and verifies that they have been anchored at the desired rate.
+    // This is a benchmark scenario for e2e testing, simliar to the recon event sync scenario,
+    // but covering using js-ceramic rather than talking directly to the ipfs API.
+    CASBenchmark,
+    
 }
 
 impl Scenario {
@@ -146,6 +153,7 @@ impl Scenario {
             Scenario::ReconEventSync => "recon_event_sync",
             Scenario::ReconEventKeySync => "recon_event_key_sync",
             Scenario::CeramicAnchoringBenchmark => "ceramic_anchoring_benchmark",
+            Scenario::CASBenchmark => "cas_benchmark",
         }
     }
 
@@ -160,6 +168,7 @@ impl Scenario {
             | Self::CeramicAnchoringBenchmark
             | Self::CeramicNewStreamsBenchmark
             | Self::CeramicQuery
+            | Self::CASBenchmark
             | Self::CeramicModelReuse => Ok(peer
                 .ceramic_addr()
                 .ok_or_else(|| {
@@ -407,6 +416,7 @@ impl ScenarioState {
             Scenario::CeramicQuery => ceramic::query::scenario(self.scenario.into()).await?,
             Scenario::ReconEventSync => recon_sync::event_sync_scenario().await?,
             Scenario::ReconEventKeySync => recon_sync::event_key_sync_scenario().await?,
+            Scenario::CASBenchmark => ceramic::anchor::cas_benchmark().await?,
         };
         self.collect_before_metrics().await?;
         Ok(scenario)
@@ -499,6 +509,7 @@ impl ScenarioState {
                 | Scenario::CeramicWriteOnly
                 | Scenario::CeramicNewStreams
                 | Scenario::CeramicQuery
+                | Scenario::CASBenchmark
                 | Scenario::CeramicModelReuse => Ok(()),
                 Scenario::CeramicNewStreamsBenchmark => {
                     // we collect things in the scenario and use redis to propagate the metrics to the manager
@@ -515,7 +526,7 @@ impl ScenarioState {
                 Scenario::CeramicAnchoringBenchmark => {
                     self.before_metrics = Some(
                         self.get_peers_counter_metric(
-                            &CERAMIC_CAS_REQUESTED_METRIC_NAME,
+                            CERAMIC_CAS_REQUESTED_METRIC_NAME,
                             PROM_METRICS_PATH,
                         )
                         .await?,
@@ -542,6 +553,7 @@ impl ScenarioState {
             | Scenario::CeramicWriteOnly
             | Scenario::CeramicNewStreams
             | Scenario::CeramicQuery
+            | Scenario::CASBenchmark
             | Scenario::CeramicModelReuse => (CommandResult::Success, None),
             Scenario::CeramicNewStreamsBenchmark => {
                 let res =
@@ -716,9 +728,9 @@ impl ScenarioState {
         sleep(wait_duration).await;
 
         // Pick a peer at random
-        let peer = self.peers.iter().next().unwrap();
+        let peer = self.peers.first().unwrap();
 
-        let ids = self.get_set_from_redis("anchor_mids").await?;
+        let ids = self.get_set_from_redis(ANCHOR_REQUEST_MIDS_KEY).await?;
         info!("Number of MIDs: {}", ids.len());
 
         // Make an API call to get the status of request from the chosen peer
@@ -740,9 +752,10 @@ impl ScenarioState {
         }
 
         // remove stream ids from redis
-        self.remove_stream_from_redis("anchor_mids", ids).await?;
+        self.remove_stream_from_redis(ANCHOR_REQUEST_MIDS_KEY, ids)
+            .await?;
 
-        // TODO_3164_5 : Report these counts to Graphana
+        // TODO_3164_5 : Report these counts to Graphana : open telemetry emit how its done in MetricsInner
 
         // Log the counts
         info!("Not requested count: {:2}", not_requested_count);
@@ -828,6 +841,7 @@ impl ScenarioState {
             | Scenario::CeramicQuery
             | Scenario::CeramicModelReuse
             | Scenario::CeramicAnchoringBenchmark
+            | Scenario::CASBenchmark
             | Scenario::CeramicNewStreamsBenchmark => (CommandResult::Success, None),
             Scenario::ReconEventSync | Scenario::ReconEventKeySync => {
                 let default_rate = 300;


### PR DESCRIPTION
Load test that only generates load currently. We are storing the streams in redis if in future we want to perform a validation on this test. 

Currently, this test is being used generate load on cas and we monitor the dashboard to ensure CAS is not falling over. 

Since Goose is distributed load generator it is easier to generate load using this scenario compared to pocket-knife.

This scenario creates a Goose transaction which hits the CAS createAnchor API. Most of the code in anchor.rs creates an auth payload for the PUT request and a CAR file