### PR TITLE
chore: disable goose logs by default

### DIFF
--- a/operator/src/simulation/controller.rs
+++ b/operator/src/simulation/controller.rs
@@ -182,6 +182,7 @@ async fn reconcile_(
         job_image_config: job_image_config.clone(),
         throttle_requests: spec.throttle_requests,
         success_request_target: spec.success_request_target,
+        log_level: spec.log_level.clone(),
     };
 
     apply_manager(cx.clone(), &ns, simulation.clone(), manager_config).await?;

--- a/operator/src/simulation/manager.rs
+++ b/operator/src/simulation/manager.rs
@@ -37,6 +37,7 @@ pub struct ManagerConfig {
     pub nonce: u32,
     pub job_image_config: JobImageConfig,
     pub success_request_target: Option<usize>,
+    pub log_level: Option<String>,
 }
 
 pub fn manager_job_spec(config: ManagerConfig) -> JobSpec {
@@ -127,6 +128,13 @@ pub fn manager_job_spec(config: ManagerConfig) -> JobSpec {
         env_vars.push(EnvVar {
             name: "SIMULATE_TARGET_REQUESTS".to_owned(),
             value: Some(success_request_target.to_string()),
+            ..Default::default()
+        })
+    }
+    if let Some(log_level) = config.log_level {
+        env_vars.push(EnvVar {
+            name: "SIMULATE_LOG_LEVEL".to_owned(),
+            value: Some(log_level),
             ..Default::default()
         })
     }

--- a/operator/src/simulation/spec.rs
+++ b/operator/src/simulation/spec.rs
@@ -34,6 +34,11 @@ pub struct SimulationSpec {
     /// Enable dev mode for the simulation. This will remove resource limits that are not
     /// explicitly set in the simulation spec.
     pub(crate) dev_mode: Option<bool>,
+    /// Log level to use. On the manager writes to stdout, and on the workers will write
+    /// files for the simulation. The files may not be flushed until the simulation is complete
+    /// which consumes RAM, and will disappear if there is no persistent volume when the pod exits.
+    /// Valid values: 'off', 'warn', 'info', 'debug', 'trace'. Defaults to 'off'.
+    pub(crate) log_level: Option<String>,
 }
 
 impl Simulation {

--- a/operator/src/simulation/spec.rs
+++ b/operator/src/simulation/spec.rs
@@ -37,7 +37,7 @@ pub struct SimulationSpec {
     /// Log level to use. On the manager writes to stdout, and on the workers will write
     /// files for the simulation. The files may not be flushed until the simulation is complete
     /// which consumes RAM, and will disappear if there is no persistent volume when the pod exits.
-    /// Valid values: 'off', 'warn', 'info', 'debug', 'trace'. Defaults to 'off'.
+    /// Valid values: 'warn', 'info', 'debug', 'trace'. Defaults to None meaning no logging beyond RUST_LOG.
     pub(crate) log_level: Option<String>,
 }
 

--- a/runner/src/simulate.rs
+++ b/runner/src/simulate.rs
@@ -67,6 +67,10 @@ pub struct Opts {
     #[arg(long, env = "SIMULATE_RUN_TIME", default_value = "10m")]
     run_time: String,
 
+    /// Whether to log the scenario tx, req, errors to a file at a given level.
+    #[arg(long, env = "SIMULATE_LOG_LEVEL", default_value = "off")]
+    log_level: LogLevel,
+
     /// Unique value per test run to ensure uniqueness across different test runs.
     /// All workers and manager must be given the same nonce.
     #[arg(long, env = "SIMULATE_NONCE")]
@@ -81,6 +85,31 @@ pub struct Opts {
     /// left to the scenario (requests per second, total requests, rps/node etc).
     #[arg(long, env = "SIMULATE_TARGET_REQUESTS")]
     target_request_rate: Option<usize>,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum LogLevel {
+    Off,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl LogLevel {
+    fn is_enabled(&self) -> bool {
+        !matches!(self, LogLevel::Off)
+    }
+
+    fn as_goose_log_level(&self) -> u8 {
+        match self {
+            LogLevel::Off => panic!("LogLevel::Off should not be used as an integer (it is None)."),
+            LogLevel::Warn => 0,
+            LogLevel::Info => 1,
+            LogLevel::Debug => 2,
+            LogLevel::Trace => 3,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -322,6 +351,7 @@ struct ScenarioState {
     metrics_collector: MetricsCollector,
     before_metrics: Option<Vec<PeerRequestMetricInfo>>,
     run_time: String,
+    log_level: LogLevel,
     throttle_requests: Option<usize>,
 }
 
@@ -362,6 +392,7 @@ impl ScenarioState {
             target_request_rate: opts.target_request_rate,
             before_metrics: None,
             run_time: opts.run_time,
+            log_level: opts.log_level,
             throttle_requests: opts.throttle_requests,
         })
     }
@@ -661,7 +692,26 @@ impl ScenarioState {
     fn goose_config(&self) -> Result<GooseConfiguration> {
         let config = if self.manager {
             let mut config = GooseConfiguration::default();
-            config.log_level = 2;
+            if self.log_level.is_enabled() {
+                // wow this is annoying but we're going to match goose internals here
+                match self.log_level {
+                    LogLevel::Off => unreachable!("LogLevel is enabled so can't be off"),
+                    LogLevel::Warn => {
+                        config.verbose = 0;
+                        config.quiet = 1;
+                    }
+                    LogLevel::Info => {
+                        config.verbose = 0;
+                        config.quiet = 0;
+                    }
+                    LogLevel::Debug => {
+                        config.verbose = 1;
+                    }
+                    LogLevel::Trace => {
+                        config.verbose = 2;
+                    }
+                }
+            }
             config.users = Some(self.topo.users);
             config.manager = true;
             config.manager_bind_port = 5115;
@@ -671,11 +721,14 @@ impl ScenarioState {
             config
         } else {
             let mut config = GooseConfiguration::default();
-            config.scenario_log = "scenario.log".to_owned();
-            config.transaction_log = "transaction.log".to_owned();
-            config.request_log = "request.log".to_owned();
-            config.error_log = "error.log".to_owned();
-            config.log_level = 2;
+            // we could set `config.verbose` which is for stdout, but for now we just use files as it doesn't seem to do anything on workers
+            if self.log_level.is_enabled() {
+                config.log_level = self.log_level.as_goose_log_level();
+                config.scenario_log = "scenario.log".to_owned();
+                config.transaction_log = "transaction.log".to_owned();
+                config.request_log = "request.log".to_owned();
+                config.error_log = "error.log".to_owned();
+            }
             config.worker = true;
             config.host = self.target_peer_addr()?;
             // We are leveraging k8s dns search path so we do not have to specify the fully qualified
@@ -1070,6 +1123,7 @@ mod test {
             run_time: "60".into(),
             nonce: 42,
             throttle_requests: None,
+            log_level: LogLevel::Off,
             target_request_rate,
         }
     }


### PR DESCRIPTION
Don't write goose log files on workers unless requested. This will write goose logs to the manager stdout as well at the desired level. The simulation spec has a new field `logLevel: warn/info/debug/trace` and defaults to None (meaning off) if not set. This is a change, but these files haven't been generally useful afaik and it seems to consume a lot of RAM as they don't appear to be flushed until the end of the run. 

This requires redeploying the CRDs and the operator and runner images.