### PR TITLE
chore: Less flaky results from scenario validation

### DIFF
--- a/keramik/src/simulation.md
+++ b/keramik/src/simulation.md
@@ -7,8 +7,7 @@ To run a simulation, first define a simulation. Available simulation types are
 - `ceramic-write-only` - A simulation that only performs updates on two different streams
 - `ceramic-new-streams` - A simulation that only creates new streams
 - `ceramic-model-reuse` - A simulation that reuses the same model and queries instances across workers
-- `recon-event-key-sync` - A simulation that creates event keys for Recon to sync at a fixed rate (~300/s by default). Designed for a 2 node network but should work on any.
-- `recon-event-sync` - A simulation that creates events for Recon to sync at a fixed rate (~300/s by default). Designed for a 2 node network but should work on any. Choosing between recon scenarios depends on what version of rust-ceramic you have. Some versions support keys only, some support key/value (maybe we'll support both someday). If you're not sure, try this one first.
+- `recon-event-sync` - A simulation that creates events for Recon to sync at a fixed rate (~300/s by default). Designed for a 2 node network but should work on any.
 
 Using one of these scenarios, we can then define the configuration for that scenario:
 

--- a/runner/src/scenario/ceramic/mod.rs
+++ b/runner/src/scenario/ceramic/mod.rs
@@ -160,7 +160,7 @@ impl From<Scenario> for CeramicScenarioParameters {
                 number_of_documents: 0,
                 store_mids: false,
             },
-            Scenario::CeramicNewStreamsBenchmark => Self {
+            Scenario::ReconEventSync | Scenario::CeramicNewStreamsBenchmark => Self {
                 did_type: DidType::UserDidKey,
                 model_reuse: ReuseType::Shared,
                 model_instance_reuse: ReuseType::PerUser,
@@ -174,10 +174,7 @@ impl From<Scenario> for CeramicScenarioParameters {
                 number_of_documents: 3,
                 store_mids: false,
             },
-            Scenario::IpfsRpc
-            | Scenario::ReconEventSync
-            | Scenario::ReconEventKeySync
-            | Scenario::CASBenchmark => {
+            Scenario::IpfsRpc | Scenario::CASBenchmark => {
                 panic!("Not supported for non ceramic scenarios")
             }
             Scenario::CeramicAnchoringBenchmark => Self {

--- a/runner/src/scenario/mod.rs
+++ b/runner/src/scenario/mod.rs
@@ -29,8 +29,3 @@ pub(crate) fn is_goose_lead_user() -> bool {
 pub(crate) fn is_goose_global_leader(lead_user: bool) -> bool {
     is_goose_lead_worker() && lead_user
 }
-
-/// Reset the lead user flag so another process can act as the lead user in the future
-pub(crate) fn reset_goose_lead_user() {
-    FIRST_USER.store(true, std::sync::atomic::Ordering::SeqCst);
-}

--- a/runner/src/simulate.rs
+++ b/runner/src/simulate.rs
@@ -525,9 +525,11 @@ impl ScenarioState {
     /// For now, most scenarios are successful if they complete without error and only EventIdSync has a criteria.
     /// Not a result to ensure we always proceed with cleanup, even if we fail to validate the scenario.
     /// Should return the Minimum RPS of all peers as the f64
+    /// Sometimes goose metrics fail to be collected, so we can try to validate the scenario without them in some cases.
     pub async fn validate_scenario_success(
         &self,
         metrics: &GooseMetrics,
+        backup_runtime: std::time::Duration,
     ) -> (CommandResult, Option<PeerRps>) {
         if !self.manager {
             return (CommandResult::Success, None);
@@ -590,19 +592,27 @@ impl ScenarioState {
                 // entirely different. Anyway, to avoid generalizing the exception we keep it simple.
                 let req_name = recon_sync::CREATE_EVENT_REQ_NAME;
 
-                let metric = match metrics
+                match metrics
                     .requests
                     .get(req_name)
                     .ok_or_else(|| anyhow!("failed to find goose metrics for request {}", req_name))
                     .map_err(CommandResult::Failure)
                 {
-                    Ok(v) => v,
-                    Err(e) => return (e, None),
+                    Ok(v) => {
+                        info!("Create events success count: {}", v.success_count);
+                    }
+                    Err(e) => {
+                        warn!(
+                            error=?e, "Failed to get create events success count from goose metrics"
+                        );
+                    }
                 };
 
-                self.validate_recon_scenario_success_int(
-                    metrics.duration as u64,
-                    metric.success_count as u64,
+                self.validate_recon_scenario_success(
+                    metrics
+                        .duration
+                        .try_into()
+                        .unwrap_or(backup_runtime.as_secs()),
                 )
                 .await
             }
@@ -745,10 +755,9 @@ impl ScenarioState {
 
     /// Removed from `validate_scenario_success` to make testing easier as constructing the GooseMetrics appropriately is difficult
     /// Should return the Minimum RPS of all peers as the f64
-    async fn validate_recon_scenario_success_int(
+    async fn validate_recon_scenario_success(
         &self,
         run_time_seconds: u64,
-        request_cnt: u64,
     ) -> (CommandResult, Option<PeerRps>) {
         if !self.manager {
             return (CommandResult::Success, None);
@@ -778,7 +787,6 @@ impl ScenarioState {
 
                 // There is no `f64::try_from::<u64 or usize>` but if these values don't fit, we have bigger problems
                 let threshold = self.target_request_rate.unwrap_or(default_rate) as f64;
-                let create_rps = request_cnt as f64 / run_time_seconds as f64;
 
                 let before_metrics = match self
                     .before_metrics
@@ -805,7 +813,7 @@ impl ScenarioState {
                     Err(e) => return (CommandResult::Failure(e), None),
                 };
 
-                let mut errors = peer_metrics.iter().flat_map(|p| {
+                let errors = peer_metrics.iter().flat_map(|p| {
                     let rps = p.rps();
                     if rps < threshold {
                         warn!(current_req_cnt=%p.count, run_time_seconds=?p.runtime, %threshold, %rps, "rps less than threshold");
@@ -828,26 +836,19 @@ impl ScenarioState {
                     Some(PeerRps::new(peer_metrics))
                 };
 
-                if create_rps < threshold {
-                    warn!(
-                        ?create_rps,
-                        ?threshold,
-                        "create rps less than threshold on writer node"
-                    );
-                    errors.push(format!(
-                        "Create event RPS less than threshold on writer node: {} < {}",
-                        create_rps, threshold
-                    ));
-                }
                 if errors.is_empty() {
                     info!(
-                        ?create_rps,
+                        ?peer_rps,
                         ?threshold,
                         "SUCCESS! All peers met the threshold"
                     );
                     (CommandResult::Success, peer_rps)
                 } else {
-                    warn!(?errors, "FAILURE! Not all peers met the threshold");
+                    warn!(
+                        ?errors,
+                        ?peer_rps,
+                        "FAILURE! Not all peers met the threshold"
+                    );
                     (CommandResult::Failure(anyhow!(errors.join("\n"))), peer_rps)
                 }
             }
@@ -922,6 +923,7 @@ pub async fn simulate(opts: Opts) -> Result<CommandResult> {
     let scenario = state.build_goose_scenario().await?;
     let config: GooseConfiguration = state.goose_config()?;
 
+    let start = std::time::Instant::now();
     let goose_metrics = match GooseAttack::initialize_with_config(config)?
         .register_scenario(scenario)
         .execute()
@@ -933,8 +935,11 @@ pub async fn simulate(opts: Opts) -> Result<CommandResult> {
             return Err(e.into());
         }
     };
+    let elapsed = start.elapsed();
 
-    let (success, peer_rps) = state.validate_scenario_success(&goose_metrics).await;
+    let (success, peer_rps) = state
+        .validate_scenario_success(&goose_metrics, elapsed)
+        .await;
     metrics.record(goose_metrics, peer_rps);
 
     Ok(success)
@@ -1315,7 +1320,6 @@ mod test {
     async fn run_event_id_sync_test(
         manager: bool,
         run_time: u64,
-        request_cnt: u64,
         target_request_rate: Option<usize>,
         metric_start_value: u64,
         metric_end_value: u64,
@@ -1329,10 +1333,7 @@ mod test {
             .unwrap();
 
         state.collect_before_metrics().await.unwrap();
-        state
-            .validate_recon_scenario_success_int(run_time, run_time * request_cnt)
-            .await
-            .0
+        state.validate_recon_scenario_success(run_time).await.0
     }
 
     #[test(tokio::test)]
@@ -1346,7 +1347,6 @@ mod test {
         match run_event_id_sync_test(
             manager,
             run_time,
-            request_cnt,
             target_rps,
             metric_start_value,
             metric_end_value,
@@ -1369,7 +1369,6 @@ mod test {
         match run_event_id_sync_test(
             manager,
             run_time,
-            request_cnt,
             target_rps,
             metric_start_value,
             metric_end_value,
@@ -1392,7 +1391,6 @@ mod test {
         match run_event_id_sync_test(
             manager,
             run_time,
-            request_cnt,
             target_rps,
             metric_start_value,
             metric_end_value,
@@ -1417,7 +1415,6 @@ mod test {
         match run_event_id_sync_test(
             manager,
             run_time,
-            request_cnt,
             target_rps,
             metric_start_value,
             metric_end_value,
@@ -1442,7 +1439,6 @@ mod test {
         match run_event_id_sync_test(
             manager,
             run_time,
-            request_cnt,
             target_rps,
             metric_start_value,
             metric_end_value,
@@ -1465,7 +1461,6 @@ mod test {
         match run_event_id_sync_test(
             manager,
             run_time,
-            request_cnt,
             target_rps,
             metric_start_value,
             metric_end_value,


### PR DESCRIPTION
We keep getting failures during longer simulations because the manager and workers disconnect at some point, and no metrics are reported by goose, however the prometheus metrics demonstrate that we would have still passed. Now we rely on goose for time, but keep a backup (this will be slightly longer and therefore won't bias us toward a better result), and use the prom metrics exclusively.

I also deleted the old recon keys only scenario as it no longer applies and is just noise.

Results from a 3 minute local test:
<img width="1591" alt="image" src="https://github.com/3box/keramik/assets/5317198/a3e02b4c-66ed-4ff4-a0ba-be54854c985f">
