### PR TITLE
feat: allow overriding cas api envars

### DIFF
--- a/keramik/src/advanced_configuration.md
+++ b/keramik/src/advanced_configuration.md
@@ -154,6 +154,25 @@ spec:
       memory: "1Gi"
 ```
 
+# CAS API Configuration
+
+The CAS API environment variables can be set or overridden through the network configuration.
+
+```yaml
+# network configuration
+---
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: small
+spec:
+  replicas: 0
+  cas:
+    api:
+      env:
+        APP_PORT: "8080"
+```
+
 # Enabling Recon
 
 You can also use Recon for reconciliation by setting 'CERAMIC_ONE_RECON' env variable to true. 

--- a/operator/src/network/cas.rs
+++ b/operator/src/network/cas.rs
@@ -45,7 +45,7 @@ pub struct CasConfig {
     pub ganache_resource_limits: ResourceLimitsConfig,
     pub postgres_resource_limits: ResourceLimitsConfig,
     pub localstack_resource_limits: ResourceLimitsConfig,
-    pub cas_api: CasApiConfig,
+    pub api: CasApiConfig,
 }
 
 #[derive(Default)]
@@ -102,7 +102,7 @@ impl Default for CasConfig {
                 memory: Some(Quantity("1Gi".to_owned())),
                 storage: Quantity("1Gi".to_owned()),
             },
-            cas_api: Default::default(),
+            api: Default::default(),
         }
     }
 }
@@ -139,7 +139,7 @@ impl From<CasSpec> for CasConfig {
                 value.localstack_resource_limits,
                 default.localstack_resource_limits,
             ),
-            cas_api: value.cas_api.map(Into::into).unwrap_or(default.cas_api),
+            api: value.api.map(Into::into).unwrap_or(default.api),
         }
     }
 }
@@ -309,7 +309,7 @@ pub fn cas_stateful_set_spec(
     datadog.inject_env(&mut cas_api_env);
 
     // Apply the CAS API env overrides, if specified.
-    override_env_vars(&mut cas_api_env, config.cas_api.env.clone());
+    override_env_vars(&mut cas_api_env, &config.api.env);
 
     StatefulSetSpec {
         replicas: Some(1),

--- a/operator/src/network/ceramic.rs
+++ b/operator/src/network/ceramic.rs
@@ -402,7 +402,7 @@ pub fn stateful_set_spec(ns: &str, bundle: &CeramicBundle<'_>) -> StatefulSetSpe
     }
 
     // Apply env overrides, if specified.
-    override_env_vars(&mut ceramic_env, bundle.config.env.clone());
+    override_env_vars(&mut ceramic_env, &bundle.config.env);
 
     let mut init_env = vec![EnvVar {
         name: "CERAMIC_ADMIN_PRIVATE_KEY".to_owned(),

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -4642,7 +4642,7 @@ mod tests {
         // Setup network spec and status
         let network = Network::test().with_spec(NetworkSpec {
             cas: Some(CasSpec {
-                cas_api: Some(CasApiSpec {
+                api: Some(CasApiSpec {
                     env: Some(BTreeMap::from_iter([
                         ("ENV_KEY_A".to_string(), "ENV_VALUE_A".to_string()),
                         ("ENV_KEY_B".to_string(), "ENV_VALUE_B".to_string()),

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -1092,6 +1092,7 @@ mod tests {
         },
     };
 
+    use crate::network::CasApiSpec;
     use expect_test::{expect, expect_file};
     use k8s_openapi::{
         api::{
@@ -2269,40 +2270,40 @@ mod tests {
                            {
             -                "env": [
             -                  {
+            -                    "name": "RUST_LOG",
+            -                    "value": "info,ceramic_one=debug,multipart=error"
+            -                  },
+            -                  {
             -                    "name": "CERAMIC_ONE_BIND_ADDRESS",
             -                    "value": "0.0.0.0:5001"
-            -                  },
-            -                  {
-            -                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-            -                    "value": "1"
-            -                  },
-            -                  {
-            -                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-            -                    "value": "6"
-            -                  },
-            -                  {
-            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-            -                    "value": "0"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
             -                    "value": "0.0.0.0:9465"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_NETWORK",
-            -                    "value": "local"
+            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+            -                    "value": "/ip4/0.0.0.0/tcp/4001"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_STORE_DIR",
             -                    "value": "/data/ipfs"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-            -                    "value": "/ip4/0.0.0.0/tcp/4001"
+            -                    "name": "CERAMIC_ONE_NETWORK",
+            -                    "value": "local"
             -                  },
             -                  {
-            -                    "name": "RUST_LOG",
-            -                    "value": "info,ceramic_one=debug,multipart=error"
+            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+            -                    "value": "0"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+            -                    "value": "6"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+            -                    "value": "1"
             -                  }
             -                ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -2398,40 +2399,40 @@ mod tests {
                            {
             -                "env": [
             -                  {
+            -                    "name": "RUST_LOG",
+            -                    "value": "info,ceramic_one=debug,multipart=error"
+            -                  },
+            -                  {
             -                    "name": "CERAMIC_ONE_BIND_ADDRESS",
             -                    "value": "0.0.0.0:5001"
-            -                  },
-            -                  {
-            -                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-            -                    "value": "1"
-            -                  },
-            -                  {
-            -                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-            -                    "value": "6"
-            -                  },
-            -                  {
-            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-            -                    "value": "0"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
             -                    "value": "0.0.0.0:9465"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_NETWORK",
-            -                    "value": "local"
+            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+            -                    "value": "/ip4/0.0.0.0/tcp/4001"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_STORE_DIR",
             -                    "value": "/data/ipfs"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-            -                    "value": "/ip4/0.0.0.0/tcp/4001"
+            -                    "name": "CERAMIC_ONE_NETWORK",
+            -                    "value": "local"
             -                  },
             -                  {
-            -                    "name": "RUST_LOG",
-            -                    "value": "info,ceramic_one=debug,multipart=error"
+            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+            -                    "value": "0"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+            -                    "value": "6"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+            -                    "value": "1"
             -                  }
             -                ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -2546,40 +2547,40 @@ mod tests {
                            {
             -                "env": [
             -                  {
+            -                    "name": "RUST_LOG",
+            -                    "value": "info,ceramic_one=debug,multipart=error"
+            -                  },
+            -                  {
             -                    "name": "CERAMIC_ONE_BIND_ADDRESS",
             -                    "value": "0.0.0.0:5001"
-            -                  },
-            -                  {
-            -                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-            -                    "value": "1"
-            -                  },
-            -                  {
-            -                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-            -                    "value": "6"
-            -                  },
-            -                  {
-            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-            -                    "value": "0"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
             -                    "value": "0.0.0.0:9465"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_NETWORK",
-            -                    "value": "local"
+            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+            -                    "value": "/ip4/0.0.0.0/tcp/4001"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_STORE_DIR",
             -                    "value": "/data/ipfs"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-            -                    "value": "/ip4/0.0.0.0/tcp/4001"
+            -                    "name": "CERAMIC_ONE_NETWORK",
+            -                    "value": "local"
             -                  },
             -                  {
-            -                    "name": "RUST_LOG",
-            -                    "value": "info,ceramic_one=debug,multipart=error"
+            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+            -                    "value": "0"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+            -                    "value": "6"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+            -                    "value": "1"
             -                  }
             -                ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -2677,10 +2678,30 @@ mod tests {
         stub.ceramics[0].stateful_set.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -236,6 +236,10 @@
-                                 "value": "0"
+            @@ -220,20 +220,32 @@
+                           {
+                             "env": [
+                               {
+            -                    "name": "RUST_LOG",
+            -                    "value": "info,ceramic_one=debug,multipart=error"
+            +                    "name": "CERAMIC_ONE_BIND_ADDRESS",
+            +                    "value": "0.0.0.0:5001"
+            +                  },
+            +                  {
+            +                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+            +                    "value": "1"
                                },
                                {
+            -                    "name": "CERAMIC_ONE_BIND_ADDRESS",
+            -                    "value": "0.0.0.0:5001"
+            +                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+            +                    "value": "6"
+                               },
+                               {
+            +                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+            +                    "value": "0"
+            +                  },
+            +                  {
             +                    "name": "CERAMIC_ONE_METRICS",
             +                    "value": "false"
             +                  },
@@ -2688,20 +2709,40 @@ mod tests {
                                  "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                                  "value": "0.0.0.0:9465"
                                },
-            @@ -252,11 +256,19 @@
-                                 "value": "/ip4/0.0.0.0/tcp/4001"
+                               {
+            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+            -                    "value": "/ip4/0.0.0.0/tcp/4001"
+            +                    "name": "CERAMIC_ONE_NETWORK",
+            +                    "value": "local"
                                },
                                {
+                                 "name": "CERAMIC_ONE_STORE_DIR",
+            @@ -240,23 +252,23 @@
+                                 "value": "/data/ipfs"
+                               },
+                               {
+            -                    "name": "CERAMIC_ONE_NETWORK",
+            -                    "value": "local"
+            +                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+            +                    "value": "/ip4/0.0.0.0/tcp/4001"
+                               },
+                               {
+            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+            -                    "value": "0"
             +                    "name": "ENV_KEY_A",
             +                    "value": "ENV_VALUE_A"
-            +                  },
-            +                  {
+                               },
+                               {
+            -                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+            -                    "value": "6"
             +                    "name": "ENV_KEY_B",
             +                    "value": "ENV_VALUE_B"
-            +                  },
-            +                  {
-                                 "name": "RUST_LOG",
-                                 "value": "info,ceramic_one=debug,multipart=error"
+                               },
+                               {
+            -                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+            -                    "value": "1"
+            +                    "name": "RUST_LOG",
+            +                    "value": "info,ceramic_one=debug,multipart=error"
                                }
                              ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -3271,7 +3312,7 @@ mod tests {
             +                    "value": "dev-unstable"
                                },
                                {
-                                 "name": "CERAMIC_ONE_STORE_DIR",
+                                 "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
             @@ -315,15 +311,15 @@
                                },
                                {
@@ -3742,23 +3783,175 @@ mod tests {
         stub.ceramics[0].stateful_set.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -102,6 +102,10 @@
+            @@ -46,16 +46,28 @@
+                             ],
+                             "env": [
                                {
-                                 "name": "CERAMIC_NETWORK_TOPIC",
-                                 "value": "/ceramic/local-0"
+            +                    "name": "CAS_API_URL",
+            +                    "value": "http://cas:8081"
             +                  },
             +                  {
+            +                    "name": "CERAMIC_CORS_ALLOWED_ORIGINS",
+            +                    "value": ".*"
+            +                  },
+            +                  {
+            +                    "name": "CERAMIC_IPFS_HOST",
+            +                    "value": "http://localhost:5001"
+            +                  },
+            +                  {
+            +                    "name": "CERAMIC_LOG_LEVEL",
+            +                    "value": "2"
+            +                  },
+            +                  {
+                                 "name": "CERAMIC_NETWORK",
+                                 "value": "local"
+                               },
+                               {
+            -                    "name": "ETH_RPC_URL",
+            -                    "value": "http://ganache:8545"
+            -                  },
+            -                  {
+            -                    "name": "CAS_API_URL",
+            -                    "value": "http://cas:8081"
+            +                    "name": "CERAMIC_NETWORK_TOPIC",
+            +                    "value": "/ceramic/local-0"
+                               },
+                               {
+                                 "name": "CERAMIC_SQLITE_PATH",
+            @@ -66,16 +78,8 @@
+                                 "value": "/ceramic-data/statestore"
+                               },
+                               {
+            -                    "name": "CERAMIC_IPFS_HOST",
+            -                    "value": "http://localhost:5001"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_CORS_ALLOWED_ORIGINS",
+            -                    "value": ".*"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_LOG_LEVEL",
+            -                    "value": "2"
+            +                    "name": "ETH_RPC_URL",
+            +                    "value": "http://ganache:8545"
+                               },
+                               {
+                                 "name": "POSTGRES_DB",
+            @@ -82,26 +86,26 @@
+                                 "value": "ceramic"
+                               },
+                               {
+            -                    "name": "POSTGRES_USER",
+            +                    "name": "POSTGRES_PASSWORD",
+                                 "valueFrom": {
+                                   "secretKeyRef": {
+            -                        "key": "username",
+            +                        "key": "password",
+                                     "name": "ceramic-postgres-auth"
+                                   }
+                                 }
+                               },
+                               {
+            -                    "name": "POSTGRES_PASSWORD",
+            +                    "name": "POSTGRES_USER",
+                                 "valueFrom": {
+                                   "secretKeyRef": {
+            -                        "key": "password",
+            +                        "key": "username",
+                                     "name": "ceramic-postgres-auth"
+                                   }
+                                 }
+                               },
+                               {
+            -                    "name": "CERAMIC_NETWORK_TOPIC",
+            -                    "value": "/ceramic/local-0"
             +                    "name": "SOME_ENV_VAR",
             +                    "value": "SOME_ENV_VALUE"
                                }
                              ],
                              "image": "ceramicnetwork/composedb:latest",
-            @@ -370,6 +374,10 @@
+            @@ -314,16 +318,28 @@
+                                 }
+                               },
                                {
-                                 "name": "CERAMIC_NETWORK_TOPIC",
-                                 "value": "/ceramic/local-0"
+            +                    "name": "CAS_API_URL",
+            +                    "value": "http://cas:8081"
             +                  },
             +                  {
+            +                    "name": "CERAMIC_CORS_ALLOWED_ORIGINS",
+            +                    "value": ".*"
+            +                  },
+            +                  {
+            +                    "name": "CERAMIC_IPFS_HOST",
+            +                    "value": "http://localhost:5001"
+            +                  },
+            +                  {
+            +                    "name": "CERAMIC_LOG_LEVEL",
+            +                    "value": "2"
+            +                  },
+            +                  {
+                                 "name": "CERAMIC_NETWORK",
+                                 "value": "local"
+                               },
+                               {
+            -                    "name": "ETH_RPC_URL",
+            -                    "value": "http://ganache:8545"
+            -                  },
+            -                  {
+            -                    "name": "CAS_API_URL",
+            -                    "value": "http://cas:8081"
+            +                    "name": "CERAMIC_NETWORK_TOPIC",
+            +                    "value": "/ceramic/local-0"
+                               },
+                               {
+                                 "name": "CERAMIC_SQLITE_PATH",
+            @@ -334,16 +350,8 @@
+                                 "value": "/ceramic-data/statestore"
+                               },
+                               {
+            -                    "name": "CERAMIC_IPFS_HOST",
+            -                    "value": "http://localhost:5001"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_CORS_ALLOWED_ORIGINS",
+            -                    "value": ".*"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_LOG_LEVEL",
+            -                    "value": "2"
+            +                    "name": "ETH_RPC_URL",
+            +                    "value": "http://ganache:8545"
+                               },
+                               {
+                                 "name": "POSTGRES_DB",
+            @@ -350,26 +358,26 @@
+                                 "value": "ceramic"
+                               },
+                               {
+            -                    "name": "POSTGRES_USER",
+            +                    "name": "POSTGRES_PASSWORD",
+                                 "valueFrom": {
+                                   "secretKeyRef": {
+            -                        "key": "username",
+            +                        "key": "password",
+                                     "name": "ceramic-postgres-auth"
+                                   }
+                                 }
+                               },
+                               {
+            -                    "name": "POSTGRES_PASSWORD",
+            +                    "name": "POSTGRES_USER",
+                                 "valueFrom": {
+                                   "secretKeyRef": {
+            -                        "key": "password",
+            +                        "key": "username",
+                                     "name": "ceramic-postgres-auth"
+                                   }
+                                 }
+                               },
+                               {
+            -                    "name": "CERAMIC_NETWORK_TOPIC",
+            -                    "value": "/ceramic/local-0"
             +                    "name": "SOME_ENV_VAR",
             +                    "value": "SOME_ENV_VALUE"
                                }
@@ -4036,40 +4229,40 @@ mod tests {
                            {
             -                "env": [
             -                  {
+            -                    "name": "RUST_LOG",
+            -                    "value": "info,ceramic_one=debug,multipart=error"
+            -                  },
+            -                  {
             -                    "name": "CERAMIC_ONE_BIND_ADDRESS",
             -                    "value": "0.0.0.0:5001"
-            -                  },
-            -                  {
-            -                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-            -                    "value": "1"
-            -                  },
-            -                  {
-            -                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-            -                    "value": "6"
-            -                  },
-            -                  {
-            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-            -                    "value": "0"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
             -                    "value": "0.0.0.0:9465"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_NETWORK",
-            -                    "value": "local"
+            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+            -                    "value": "/ip4/0.0.0.0/tcp/4001"
             -                  },
             -                  {
             -                    "name": "CERAMIC_ONE_STORE_DIR",
             -                    "value": "/data/ipfs"
             -                  },
             -                  {
-            -                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-            -                    "value": "/ip4/0.0.0.0/tcp/4001"
+            -                    "name": "CERAMIC_ONE_NETWORK",
+            -                    "value": "local"
             -                  },
             -                  {
-            -                    "name": "RUST_LOG",
-            -                    "value": "info,ceramic_one=debug,multipart=error"
+            -                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+            -                    "value": "0"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+            -                    "value": "6"
+            -                  },
+            -                  {
+            -                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+            -                    "value": "1"
             -                  }
             -                ],
             -                "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
@@ -4356,17 +4549,17 @@ mod tests {
                              "volumeMounts": [
                                {
                                  "mountPath": "/config",
-            @@ -252,6 +259,10 @@
-                                 "value": "/ip4/0.0.0.0/tcp/4001"
-                               },
+            @@ -254,6 +261,10 @@
                                {
-            +                    "name": "CERAMIC_ONE_TOKIO_CONSOLE",
-            +                    "value": "true"
+                                 "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                                 "value": "1"
             +                  },
             +                  {
-                                 "name": "RUST_LOG",
-                                 "value": "info,ceramic_one=debug,multipart=error"
+            +                    "name": "CERAMIC_ONE_TOKIO_CONSOLE",
+            +                    "value": "true"
                                }
+                             ],
+                             "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
             @@ -274,6 +285,11 @@
                                  "containerPort": 9465,
                                  "name": "metrics",
@@ -4397,17 +4590,17 @@ mod tests {
         stub.cas_ipfs_stateful_set.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -69,6 +69,10 @@
-                                 "value": "/ip4/0.0.0.0/tcp/4001"
-                               },
+            @@ -71,6 +71,10 @@
                                {
-            +                    "name": "CERAMIC_ONE_TOKIO_CONSOLE",
-            +                    "value": "true"
+                                 "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                                 "value": "1"
             +                  },
             +                  {
-                                 "name": "RUST_LOG",
-                                 "value": "info,ceramic_one=debug,multipart=error"
+            +                    "name": "CERAMIC_ONE_TOKIO_CONSOLE",
+            +                    "value": "true"
                                }
+                             ],
+                             "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",
             @@ -91,6 +95,11 @@
                                  "containerPort": 9465,
                                  "name": "metrics",
@@ -4434,6 +4627,175 @@ mod tests {
                              "volumeMounts": [
                                {
                                  "mountPath": "/data/ipfs",
+        "#]]);
+        let (testctx, api_handle) = Context::test(mock_rpc_client);
+        let fakeserver = ApiServerVerifier::new(api_handle);
+        let mocksrv = stub.run(fakeserver);
+        reconcile(Arc::new(network), testctx)
+            .await
+            .expect("reconciler");
+        timeout_after_1s(mocksrv).await;
+    }
+
+    #[tokio::test]
+    async fn cas_api_env_override() {
+        // Setup network spec and status
+        let network = Network::test().with_spec(NetworkSpec {
+            cas: Some(CasSpec {
+                cas_api: Some(CasApiSpec {
+                    env: Some(BTreeMap::from_iter([
+                        ("ENV_KEY_A".to_string(), "ENV_VALUE_A".to_string()),
+                        ("ENV_KEY_B".to_string(), "ENV_VALUE_B".to_string()),
+                        // Override one existing var
+                        ("APP_PORT".to_string(), "8080".to_string()),
+                    ])),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        let mock_rpc_client = default_ipfs_rpc_mock();
+        let mut stub = Stub::default().with_network(network.clone());
+        stub.cas_stateful_set.patch(expect![[r#"
+            --- original
+            +++ modified
+            @@ -36,8 +36,28 @@
+                           {
+                             "env": [
+                               {
+            -                    "name": "DB_NAME",
+            -                    "value": "anchor_db"
+            +                    "name": "APP_MODE",
+            +                    "value": "server"
+            +                  },
+            +                  {
+            +                    "name": "APP_PORT",
+            +                    "value": "8080"
+            +                  },
+            +                  {
+            +                    "name": "AWS_ACCESS_KEY_ID",
+            +                    "value": "."
+            +                  },
+            +                  {
+            +                    "name": "AWS_ACCOUNT_ID",
+            +                    "value": "000000000000"
+            +                  },
+            +                  {
+            +                    "name": "AWS_REGION",
+            +                    "value": "us-east-1"
+            +                  },
+            +                  {
+            +                    "name": "AWS_SECRET_ACCESS_KEY",
+            +                    "value": "."
+                               },
+                               {
+                                 "name": "DB_HOST",
+            @@ -44,42 +64,38 @@
+                                 "value": "cas-postgres"
+                               },
+                               {
+            -                    "name": "DB_USERNAME",
+            +                    "name": "DB_NAME",
+            +                    "value": "anchor_db"
+            +                  },
+            +                  {
+            +                    "name": "DB_PASSWORD",
+                                 "valueFrom": {
+                                   "secretKeyRef": {
+            -                        "key": "username",
+            +                        "key": "password",
+                                     "name": "postgres-auth"
+                                   }
+                                 }
+                               },
+                               {
+            -                    "name": "DB_PASSWORD",
+            +                    "name": "DB_USERNAME",
+                                 "valueFrom": {
+                                   "secretKeyRef": {
+            -                        "key": "password",
+            +                        "key": "username",
+                                     "name": "postgres-auth"
+                                   }
+                                 }
+                               },
+                               {
+            -                    "name": "AWS_ACCOUNT_ID",
+            -                    "value": "000000000000"
+            +                    "name": "ENV_KEY_A",
+            +                    "value": "ENV_VALUE_A"
+                               },
+                               {
+            -                    "name": "AWS_REGION",
+            -                    "value": "us-east-1"
+            -                  },
+            -                  {
+            -                    "name": "AWS_ACCESS_KEY_ID",
+            -                    "value": "."
+            +                    "name": "ENV_KEY_B",
+            +                    "value": "ENV_VALUE_B"
+                               },
+                               {
+            -                    "name": "AWS_SECRET_ACCESS_KEY",
+            -                    "value": "."
+            -                  },
+            -                  {
+            -                    "name": "SQS_QUEUE_URL",
+            -                    "value": "http://localstack:4566/000000000000/cas-anchor-dev-"
+            +                    "name": "ETH_CONTRACT_ADDRESS",
+            +                    "value": "0x231055A0852D67C7107Ad0d0DFeab60278fE6AdC"
+                               },
+                               {
+                                 "name": "ETH_GAS_LIMIT",
+            @@ -98,20 +114,20 @@
+                                 "value": "0x06dd0990d19001c57eeea6d32e8fdeee40d3945962caf18c18c3930baa5a6ec9"
+                               },
+                               {
+            -                    "name": "ETH_CONTRACT_ADDRESS",
+            -                    "value": "0x231055A0852D67C7107Ad0d0DFeab60278fE6AdC"
+            +                    "name": "LOG_LEVEL",
+            +                    "value": "debug"
+                               },
+                               {
+            -                    "name": "NODE_ENV",
+            -                    "value": "dev"
+            +                    "name": "MERKLE_CAR_STORAGE_MODE",
+            +                    "value": "s3"
+                               },
+                               {
+            -                    "name": "LOG_LEVEL",
+            -                    "value": "debug"
+            +                    "name": "METRICS_PORT",
+            +                    "value": "9464"
+                               },
+                               {
+            -                    "name": "MERKLE_CAR_STORAGE_MODE",
+            -                    "value": "s3"
+            +                    "name": "NODE_ENV",
+            +                    "value": "dev"
+                               },
+                               {
+                                 "name": "S3_BUCKET_NAME",
+            @@ -122,16 +138,8 @@
+                                 "value": "http://localstack:4566"
+                               },
+                               {
+            -                    "name": "APP_MODE",
+            -                    "value": "server"
+            -                  },
+            -                  {
+            -                    "name": "APP_PORT",
+            -                    "value": "8081"
+            -                  },
+            -                  {
+            -                    "name": "METRICS_PORT",
+            -                    "value": "9464"
+            +                    "name": "SQS_QUEUE_URL",
+            +                    "value": "http://localstack:4566/000000000000/cas-anchor-dev-"
+                               }
+                             ],
+                             "image": "ceramicnetwork/ceramic-anchor-service:latest",
         "#]]);
         let (testctx, api_handle) = Context::test(mock_rpc_client);
         let fakeserver = ApiServerVerifier::new(api_handle);

--- a/operator/src/network/ipfs.rs
+++ b/operator/src/network/ipfs.rs
@@ -203,7 +203,7 @@ impl RustIpfsConfig {
         }
 
         // Apply env overrides, if specified.
-        override_env_vars(&mut env, self.env.clone());
+        override_env_vars(&mut env, &self.env);
 
         // Construct the set of ports
         let mut ports = vec![

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -233,6 +233,17 @@ pub struct CasSpec {
     pub postgres_resource_limits: Option<ResourceLimitsSpec>,
     /// Resource limits for the LocalStack pod, applies to both requests and limits.
     pub localstack_resource_limits: Option<ResourceLimitsSpec>,
+    /// Configuration for the CAS API
+    pub cas_api: Option<CasApiSpec>,
+}
+
+/// Describes how the CAS API is configured.
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CasApiSpec {
+    /// Extra env values to pass to the image.
+    /// CAUTION: Any env vars specified in this set will override any predefined values.
+    pub env: Option<BTreeMap<String, String>>,
 }
 
 /// Describes if and how to configure datadog telemetry

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -234,7 +234,7 @@ pub struct CasSpec {
     /// Resource limits for the LocalStack pod, applies to both requests and limits.
     pub localstack_resource_limits: Option<ResourceLimitsSpec>,
     /// Configuration for the CAS API
-    pub cas_api: Option<CasApiSpec>,
+    pub api: Option<CasApiSpec>,
 }
 
 /// Describes how the CAS API is configured.

--- a/operator/src/network/testdata/ceramic_ss_1
+++ b/operator/src/network/testdata/ceramic_ss_1
@@ -220,40 +220,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_0
+++ b/operator/src/network/testdata/ceramic_ss_weighted_0
@@ -220,40 +220,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_1
+++ b/operator/src/network/testdata/ceramic_ss_weighted_1
@@ -220,40 +220,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_2
+++ b/operator/src/network/testdata/ceramic_ss_weighted_2
@@ -220,40 +220,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_3
+++ b/operator/src/network/testdata/ceramic_ss_weighted_3
@@ -220,40 +220,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_4
+++ b/operator/src/network/testdata/ceramic_ss_weighted_4
@@ -220,40 +220,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_5
+++ b/operator/src/network/testdata/ceramic_ss_weighted_5
@@ -220,40 +220,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_6
+++ b/operator/src/network/testdata/ceramic_ss_weighted_6
@@ -220,40 +220,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_7
+++ b/operator/src/network/testdata/ceramic_ss_weighted_7
@@ -220,40 +220,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_8
+++ b/operator/src/network/testdata/ceramic_ss_weighted_8
@@ -220,40 +220,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/ceramic_ss_weighted_9
+++ b/operator/src/network/testdata/ceramic_ss_weighted_9
@@ -220,40 +220,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/default_stubs/cas_ipfs_stateful_set
+++ b/operator/src/network/testdata/default_stubs/cas_ipfs_stateful_set
@@ -37,40 +37,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/network/testdata/default_stubs/ceramic_stateful_set
+++ b/operator/src/network/testdata/default_stubs/ceramic_stateful_set
@@ -220,40 +220,40 @@ Request {
               {
                 "env": [
                   {
+                    "name": "RUST_LOG",
+                    "value": "info,ceramic_one=debug,multipart=error"
+                  },
+                  {
                     "name": "CERAMIC_ONE_BIND_ADDRESS",
                     "value": "0.0.0.0:5001"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
-                    "value": "1"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
-                    "value": "6"
-                  },
-                  {
-                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
-                    "value": "0"
                   },
                   {
                     "name": "CERAMIC_ONE_METRICS_BIND_ADDRESS",
                     "value": "0.0.0.0:9465"
                   },
                   {
-                    "name": "CERAMIC_ONE_NETWORK",
-                    "value": "local"
+                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
+                    "value": "/ip4/0.0.0.0/tcp/4001"
                   },
                   {
                     "name": "CERAMIC_ONE_STORE_DIR",
                     "value": "/data/ipfs"
                   },
                   {
-                    "name": "CERAMIC_ONE_SWARM_ADDRESSES",
-                    "value": "/ip4/0.0.0.0/tcp/4001"
+                    "name": "CERAMIC_ONE_NETWORK",
+                    "value": "local"
                   },
                   {
-                    "name": "RUST_LOG",
-                    "value": "info,ceramic_one=debug,multipart=error"
+                    "name": "CERAMIC_ONE_LOCAL_NETWORK_ID",
+                    "value": "0"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_REPLICATION",
+                    "value": "6"
+                  },
+                  {
+                    "name": "CERAMIC_ONE_KADEMLIA_PARALLELISM",
+                    "value": "1"
                   }
                 ],
                 "image": "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest",

--- a/operator/src/utils/mod.rs
+++ b/operator/src/utils/mod.rs
@@ -320,7 +320,7 @@ pub fn generate_random_secret(
 }
 
 /// Apply override env vars to an existing env var list
-pub fn override_env_vars(env: &mut Vec<EnvVar>, overrides: Option<BTreeMap<String, String>>) {
+pub fn override_env_vars(env: &mut Vec<EnvVar>, overrides: &Option<BTreeMap<String, String>>) {
     if let Some(override_env) = &overrides {
         override_env.iter().for_each(|(key, value)| {
             if let Some((pos, _)) = env.iter().enumerate().find(|(_, var)| &var.name == key) {

--- a/operator/src/utils/mod.rs
+++ b/operator/src/utils/mod.rs
@@ -10,7 +10,7 @@ use k8s_openapi::{
     api::{
         apps::v1::{StatefulSet, StatefulSetSpec, StatefulSetStatus},
         batch::v1::{Job, JobSpec, JobStatus},
-        core::v1::{ConfigMap, Service, ServiceAccount, ServiceSpec, ServiceStatus},
+        core::v1::{ConfigMap, EnvVar, Service, ServiceAccount, ServiceSpec, ServiceStatus},
         rbac::v1::{ClusterRole, ClusterRoleBinding},
     },
     apimachinery::pkg::apis::meta::v1::OwnerReference,
@@ -317,4 +317,22 @@ pub fn generate_random_secret(
     let mut rng = cx.rng.lock().expect("should be able to acquire lock");
     rng.fill_bytes(&mut secret_bytes);
     hex::encode(secret_bytes)
+}
+
+/// Apply override env vars to an existing env var list
+pub fn override_env_vars(env: &mut Vec<EnvVar>, overrides: Option<BTreeMap<String, String>>) {
+    if let Some(override_env) = &overrides {
+        override_env.iter().for_each(|(key, value)| {
+            if let Some((pos, _)) = env.iter().enumerate().find(|(_, var)| &var.name == key) {
+                env.swap_remove(pos);
+            }
+            env.push(EnvVar {
+                name: key.to_string(),
+                value: Some(value.to_string()),
+                ..Default::default()
+            })
+        });
+        // Sort env vars so we can have stable tests
+        env.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+    }
 }


### PR DESCRIPTION
I moved the env overriding logic to a utility function, and included the sorting in there as well. This caused a lot of the test files to churn, but hopefully this will make them more consistent going forward.