### PR TITLE
chore: skip u\0000 when generating model random data

### DIFF
--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -4459,7 +4459,6 @@ mod tests {
                         // Override one existing var
                         ("APP_PORT".to_string(), "8080".to_string()),
                     ])),
-                    ..Default::default()
                 }),
                 ..Default::default()
             }),

--- a/operator/src/network/stub.rs
+++ b/operator/src/network/stub.rs
@@ -42,6 +42,12 @@ impl WithStatus for Network {
     }
 }
 
+type PodMonitorStub = (
+    (ExpectFile, bool),
+    Option<(ExpectFile, bool)>,
+    Option<ExpectFile>,
+);
+
 /// Stub of expected requests during reconciliation.
 ///
 /// ```no_run
@@ -59,11 +65,7 @@ pub struct Stub {
     pub namespace: ExpectPatch<ExpectFile>,
     pub status: ExpectPatch<ExpectFile>,
     pub monitoring: Vec<ExpectFile>,
-    pub pod_monitor: Vec<(
-        (ExpectFile, bool),
-        Option<(ExpectFile, bool)>,
-        Option<ExpectFile>,
-    )>,
+    pub pod_monitor: Vec<PodMonitorStub>,
     pub cas_postgres_auth_secret: (ExpectPatch<ExpectFile>, Secret, bool),
     pub ceramic_postgres_auth_secret: (ExpectPatch<ExpectFile>, Secret),
     pub ceramic_admin_secret_missing: (ExpectPatch<ExpectFile>, Option<Secret>),

--- a/runner/src/scenario/ceramic/models.rs
+++ b/runner/src/scenario/ceramic/models.rs
@@ -74,11 +74,11 @@ impl LargeModel {
 impl RandomModelInstance for LargeModel {
     fn random() -> Self {
         let mut rng = thread_rng();
-        let name: String = (1..100).map(|_| rng.gen::<char>()).collect();
+        let name = Alphanumeric.sample_string(&mut rand::thread_rng(), 100);
         Self {
             creator: "keramik".to_string(),
             name: format!("keramik-large-model-{}", name),
-            description: (1..1_000).map(|_| rng.gen::<char>()).collect(),
+            description: Alphanumeric.sample_string(&mut rand::thread_rng(), 1000),
             tpe: rng.gen_range(0..100),
         }
     }

--- a/runner/src/scenario/ceramic/models.rs
+++ b/runner/src/scenario/ceramic/models.rs
@@ -78,7 +78,10 @@ impl RandomModelInstance for LargeModel {
         Self {
             creator: "keramik".to_string(),
             name: format!("keramik-large-model-{}", name),
-            description: Alphanumeric.sample_string(&mut rand::thread_rng(), 1000),
+            description: (0..1_000)
+                .map(|_| rng.gen::<char>())
+                .filter(|c| *c != '\u{0000}')
+                .collect(),
             tpe: rng.gen_range(0..100),
         }
     }


### PR DESCRIPTION
Currently getting u\0000 codepoints in the data, that crashes the postgres indexer because it's not allowed in jsonb data.