### PR TITLE
chore: update http client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,34 +703,8 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.9.0"
-source = "git+https://github.com/3box/rust-ceramic?branch=main#dba11dadf30ac9cf6bb98223c92c9f7014f9eb8b"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.21.7",
- "cid 0.10.1",
- "did-method-key",
- "did-pkh",
- "hex",
- "int-enum",
- "libp2p-identity",
- "minicbor",
- "multibase 0.9.1",
- "once_cell",
- "regex",
- "serde",
- "serde_bytes",
- "serde_ipld_dagcbor 0.3.0",
- "serde_json",
- "ssi",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "ceramic-core"
-version = "0.17.0"
-source = "git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main#032981d6699a937a217ab466926668c3eb0d5dbb"
+version = "0.18.0"
+source = "git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main#c803ac49ec7b136a3aca42927c5696649238841a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -749,7 +723,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_bytes",
- "serde_ipld_dagcbor 0.6.1",
+ "serde_ipld_dagcbor",
  "serde_json",
  "ssi",
  "unsigned-varint 0.8.0",
@@ -757,29 +731,32 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.9.0"
-source = "git+https://github.com/3box/rust-ceramic?branch=main#dba11dadf30ac9cf6bb98223c92c9f7014f9eb8b"
+version = "0.18.0"
+source = "git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main#c803ac49ec7b136a3aca42927c5696649238841a"
 dependencies = [
  "anyhow",
- "ceramic-core 0.9.0",
- "multihash 0.18.1",
- "once_cell",
- "rand",
+ "async-trait",
+ "ceramic-core",
+ "cid 0.11.1",
+ "ipld-core",
+ "multihash-codetable",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "ceramic-http-client"
 version = "0.1.0"
-source = "git+https://github.com/3box/ceramic-http-client-rs.git?branch=main#be4b848c2a178e860eb17941ddc430b5e91c4f9f"
+source = "git+https://github.com/3box/ceramic-http-client-rs.git?branch=main#ffa148277f686b694100430f0125e65169c9f548"
 dependencies = [
  "anyhow",
  "ceramic-event",
- "json-patch",
+ "json-patch 2.0.0",
+ "once_cell",
+ "rand",
  "schemars",
  "serde",
  "serde_json",
- "ssi",
 ]
 
 [[package]]
@@ -812,20 +789,6 @@ dependencies = [
  "core2",
  "multibase 0.9.1",
  "multihash 0.16.3",
- "serde",
- "serde_bytes",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "cid"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
-dependencies = [
- "core2",
- "multibase 0.9.1",
- "multihash 0.18.1",
  "serde",
  "serde_bytes",
  "unsigned-varint 0.7.2",
@@ -1738,6 +1701,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,14 +2456,14 @@ dependencies = [
 
 [[package]]
 name = "iroh-car"
-version = "0.17.0"
-source = "git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main#032981d6699a937a217ab466926668c3eb0d5dbb"
+version = "0.18.0"
+source = "git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main#c803ac49ec7b136a3aca42927c5696649238841a"
 dependencies = [
  "cid 0.11.1",
  "futures",
  "integer-encoding",
  "serde",
- "serde_ipld_dagcbor 0.6.1",
+ "serde_ipld_dagcbor",
  "thiserror",
  "tokio",
 ]
@@ -2683,6 +2655,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "json-syntax"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,6 +2696,17 @@ dependencies = [
  "regex",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+dependencies = [
+ "fluent-uri",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2837,7 +2832,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.7",
- "ceramic-core 0.17.0",
+ "ceramic-core",
  "ceramic-http-client",
  "chrono",
  "clap",
@@ -2858,7 +2853,7 @@ dependencies = [
  "reqwest",
  "schemars",
  "serde",
- "serde_ipld_dagcbor 0.6.1",
+ "serde_ipld_dagcbor",
  "serde_ipld_dagjson",
  "serde_json",
  "test-log",
@@ -2926,7 +2921,7 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "http",
- "json-patch",
+ "json-patch 1.2.0",
  "k8s-openapi",
  "once_cell",
  "schemars",
@@ -2960,7 +2955,7 @@ dependencies = [
  "derivative",
  "futures",
  "hashbrown 0.14.3",
- "json-patch",
+ "json-patch 1.2.0",
  "k8s-openapi",
  "kube-client",
  "parking_lot",
@@ -3411,25 +3406,6 @@ name = "multihash"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
-dependencies = [
- "blake2b_simd 1.0.2",
- "blake2s_simd",
- "blake3",
- "core2",
- "digest 0.10.7",
- "multihash-derive 0.8.0",
- "serde",
- "serde-big-array",
- "sha2 0.10.8",
- "sha3",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multihash"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
 dependencies = [
  "blake2b_simd 1.0.2",
  "blake2s_simd",
@@ -4882,18 +4858,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "serde_ipld_dagcbor"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2433e94ffb5977e67afbd75733abd6ada1c4f497125894a8c89b3fdc5fd6a058"
-dependencies = [
- "cbor4ii",
- "cid 0.8.6",
- "scopeguard",
- "serde",
 ]
 
 [[package]]

--- a/runner/src/scenario/ceramic/anchor.rs
+++ b/runner/src/scenario/ceramic/anchor.rs
@@ -35,7 +35,8 @@ async fn auth_header(url: String, controller: String, digest: Cid) -> Result<Str
     let signer = JwkSigner::new(DidDocument::new(controller.as_str()), &node_private_key)
         .await
         .unwrap();
-    let auth_jws = Jws::for_data(&signer, &auth_payload).await?;
+    let auth_jws = Jws::builder(&signer).build_for_data(&auth_payload).await?;
+
     let (sig, protected) = auth_jws
         .signatures
         .first()

--- a/runner/src/scenario/ceramic/model_instance.rs
+++ b/runner/src/scenario/ceramic/model_instance.rs
@@ -641,7 +641,7 @@ impl ModelInstanceRequests {
         Ok(resp.stream_id)
     }
 
-    pub async fn create_model_instance<T: serde::Serialize>(
+    pub async fn create_model_instance<T: serde::Serialize + Send + Sync>(
         user: &mut GooseUser,
         cli: &CeramicClient,
         model: &StreamId,


### PR DESCRIPTION
This updates the [rust-ceramic](https://github.com/ceramicnetwork/rust-ceramic/pull/351) and [ceramic http client](https://github.com/3box/ceramic-http-client-rs/pull/17) dependencies.