### PR TITLE
fix: update default resources for rust ipfs

### DIFF
--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -2317,6 +2317,25 @@ mod tests {
                              "name": "ipfs",
                              "ports": [
                                {
+            @@ -278,14 +240,14 @@
+                             ],
+                             "resources": {
+                               "limits": {
+            -                    "cpu": "1",
+            +                    "cpu": "250m",
+                                 "ephemeral-storage": "1Gi",
+            -                    "memory": "1Gi"
+            +                    "memory": "512Mi"
+                               },
+                               "requests": {
+            -                    "cpu": "1",
+            +                    "cpu": "250m",
+                                 "ephemeral-storage": "1Gi",
+            -                    "memory": "1Gi"
+            +                    "memory": "512Mi"
+                               }
+                             },
+                             "volumeMounts": [
             @@ -292,6 +254,11 @@
                                {
                                  "mountPath": "/data/ipfs",
@@ -2450,17 +2469,17 @@ mod tests {
                              ],
                              "resources": {
                                "limits": {
-            -                    "cpu": "250m",
+            -                    "cpu": "1",
             -                    "ephemeral-storage": "1Gi",
-            -                    "memory": "512Mi"
+            -                    "memory": "1Gi"
             +                    "cpu": "4",
             +                    "ephemeral-storage": "4Gi",
             +                    "memory": "4Gi"
                                },
                                "requests": {
-            -                    "cpu": "250m",
+            -                    "cpu": "1",
             -                    "ephemeral-storage": "1Gi",
-            -                    "memory": "512Mi"
+            -                    "memory": "1Gi"
             +                    "cpu": "4",
             +                    "ephemeral-storage": "4Gi",
             +                    "memory": "4Gi"
@@ -2594,6 +2613,25 @@ mod tests {
                              "name": "ipfs",
                              "ports": [
                                {
+            @@ -278,14 +240,14 @@
+                             ],
+                             "resources": {
+                               "limits": {
+            -                    "cpu": "1",
+            +                    "cpu": "250m",
+                                 "ephemeral-storage": "1Gi",
+            -                    "memory": "1Gi"
+            +                    "memory": "512Mi"
+                               },
+                               "requests": {
+            -                    "cpu": "1",
+            +                    "cpu": "250m",
+                                 "ephemeral-storage": "1Gi",
+            -                    "memory": "1Gi"
+            +                    "memory": "512Mi"
+                               }
+                             },
+                             "volumeMounts": [
             @@ -292,6 +254,16 @@
                                {
                                  "mountPath": "/data/ipfs",
@@ -2718,17 +2756,17 @@ mod tests {
                              ],
                              "resources": {
                                "limits": {
-            -                    "cpu": "250m",
+            -                    "cpu": "1",
             -                    "ephemeral-storage": "1Gi",
-            -                    "memory": "512Mi"
+            -                    "memory": "1Gi"
             +                    "cpu": "4",
             +                    "ephemeral-storage": "4Gi",
             +                    "memory": "4Gi"
                                },
                                "requests": {
-            -                    "cpu": "250m",
+            -                    "cpu": "1",
             -                    "ephemeral-storage": "1Gi",
-            -                    "memory": "512Mi"
+            -                    "memory": "1Gi"
             +                    "cpu": "4",
             +                    "ephemeral-storage": "4Gi",
             +                    "memory": "4Gi"
@@ -2930,17 +2968,17 @@ mod tests {
                              ],
                              "resources": {
                                "limits": {
-            -                    "cpu": "250m",
+            -                    "cpu": "1",
             -                    "ephemeral-storage": "1Gi",
-            -                    "memory": "512Mi"
+            -                    "memory": "1Gi"
             +                    "cpu": "2",
             +                    "ephemeral-storage": "2Gi",
             +                    "memory": "2Gi"
                                },
                                "requests": {
-            -                    "cpu": "250m",
+            -                    "cpu": "1",
             -                    "ephemeral-storage": "1Gi",
-            -                    "memory": "512Mi"
+            -                    "memory": "1Gi"
             +                    "cpu": "2",
             +                    "ephemeral-storage": "2Gi",
             +                    "memory": "2Gi"
@@ -4086,6 +4124,25 @@ mod tests {
                              "name": "ipfs",
                              "ports": [
                                {
+            @@ -278,14 +240,14 @@
+                             ],
+                             "resources": {
+                               "limits": {
+            -                    "cpu": "1",
+            +                    "cpu": "250m",
+                                 "ephemeral-storage": "1Gi",
+            -                    "memory": "1Gi"
+            +                    "memory": "512Mi"
+                               },
+                               "requests": {
+            -                    "cpu": "1",
+            +                    "cpu": "250m",
+                                 "ephemeral-storage": "1Gi",
+            -                    "memory": "1Gi"
+            +                    "memory": "512Mi"
+                               }
+                             },
+                             "volumeMounts": [
             @@ -292,6 +254,11 @@
                                {
                                  "mountPath": "/data/ipfs",
@@ -4410,7 +4467,7 @@ mod tests {
                              ],
                              "resources": {
             @@ -288,6 +313,13 @@
-                                 "memory": "512Mi"
+                                 "memory": "1Gi"
                                }
                              },
             +                "securityContext": {
@@ -4462,7 +4519,7 @@ mod tests {
                              ],
                              "resources": {
             @@ -105,6 +114,13 @@
-                                 "memory": "512Mi"
+                                 "memory": "1Gi"
                                }
                              },
             +                "securityContext": {

--- a/operator/src/network/ipfs.rs
+++ b/operator/src/network/ipfs.rs
@@ -119,8 +119,8 @@ impl Default for RustIpfsConfig {
             image: "public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest".to_owned(),
             image_pull_policy: "Always".to_owned(),
             resource_limits: ResourceLimitsConfig {
-                cpu: Some(Quantity("250m".to_owned())),
-                memory: Some(Quantity("512Mi".to_owned())),
+                cpu: Some(Quantity("1".to_owned())),
+                memory: Some(Quantity("1Gi".to_owned())),
                 storage: Quantity("1Gi".to_owned()),
             },
             storage_class: None,

--- a/operator/src/network/testdata/ceramic_ss_1
+++ b/operator/src/network/testdata/ceramic_ss_1
@@ -278,14 +278,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [

--- a/operator/src/network/testdata/ceramic_ss_weighted_0
+++ b/operator/src/network/testdata/ceramic_ss_weighted_0
@@ -278,14 +278,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [

--- a/operator/src/network/testdata/ceramic_ss_weighted_1
+++ b/operator/src/network/testdata/ceramic_ss_weighted_1
@@ -278,14 +278,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [

--- a/operator/src/network/testdata/ceramic_ss_weighted_2
+++ b/operator/src/network/testdata/ceramic_ss_weighted_2
@@ -278,14 +278,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [

--- a/operator/src/network/testdata/ceramic_ss_weighted_3
+++ b/operator/src/network/testdata/ceramic_ss_weighted_3
@@ -278,14 +278,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [

--- a/operator/src/network/testdata/ceramic_ss_weighted_4
+++ b/operator/src/network/testdata/ceramic_ss_weighted_4
@@ -278,14 +278,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [

--- a/operator/src/network/testdata/ceramic_ss_weighted_5
+++ b/operator/src/network/testdata/ceramic_ss_weighted_5
@@ -278,14 +278,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [

--- a/operator/src/network/testdata/ceramic_ss_weighted_6
+++ b/operator/src/network/testdata/ceramic_ss_weighted_6
@@ -278,14 +278,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [

--- a/operator/src/network/testdata/ceramic_ss_weighted_7
+++ b/operator/src/network/testdata/ceramic_ss_weighted_7
@@ -278,14 +278,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [

--- a/operator/src/network/testdata/ceramic_ss_weighted_8
+++ b/operator/src/network/testdata/ceramic_ss_weighted_8
@@ -278,14 +278,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [

--- a/operator/src/network/testdata/ceramic_ss_weighted_9
+++ b/operator/src/network/testdata/ceramic_ss_weighted_9
@@ -278,14 +278,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [

--- a/operator/src/network/testdata/default_stubs/cas_ipfs_stateful_set
+++ b/operator/src/network/testdata/default_stubs/cas_ipfs_stateful_set
@@ -95,14 +95,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [

--- a/operator/src/network/testdata/default_stubs/ceramic_stateful_set
+++ b/operator/src/network/testdata/default_stubs/ceramic_stateful_set
@@ -278,14 +278,14 @@ Request {
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   },
                   "requests": {
-                    "cpu": "250m",
+                    "cpu": "1",
                     "ephemeral-storage": "1Gi",
-                    "memory": "512Mi"
+                    "memory": "1Gi"
                   }
                 },
                 "volumeMounts": [


### PR DESCRIPTION
As we know having less than 1 cpu can cause the odd deadlock in the C1 process. This makes the default a sane default.
