### PR TITLE
feat: support configuring persistent storage for containers

### DIFF
--- a/keramik/src/advanced_configuration.md
+++ b/keramik/src/advanced_configuration.md
@@ -70,6 +70,45 @@ and adding the following environment variables to the `spec/template/spec/contai
 
 # Image Resources
 
+## Storage
+
+Nearly all containers (monitoring outstanding), allow configuring the peristent storage size and class. The storage class must be created out of band, but can be included. The storage configuration has two keys (`size` and `class`) and can be used like so:
+
+```yaml
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: small
+spec:
+  replicas: 2
+  bootstrap: 
+    image: keramik/runner:dev
+    imagePullPolicy: IfNotPresent
+  cas:
+    casStorage:
+      size: "3Gi"
+      class: "fastDisk" # typically not set
+    ipfs:
+      go:
+        storage:
+          size: "1Gi"
+    ganacheStorage:
+      size: "1Gi"
+    postgresStorage:
+      size: "3Gi"
+    localstackStorage:
+      size: "5Gi"
+  ceramic:
+    - ipfs:
+        rust: 
+          storage:
+            size: "3Gi"
+
+```
+
+
+## Requests / Limits
+
 During local benchmarking, you may not have enough resources to run the cluster. A simple "fix" is to use the `devMode` flag on the network and simulation specs. This will override the resource requests and limits values to be none, which means it doesn't need available resources to deploy, and can consume as much as it desires. This would be problematic in production and should only be used for testing purposes.
 
 ```yaml

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -1087,8 +1087,8 @@ mod tests {
             ipfs_rpc::{tests::MockIpfsRpcClientTest, Peer},
             stub::{CeramicStub, Stub},
             BootstrapSpec, CasSpec, CeramicSpec, DataDogSpec, GoIpfsSpec, IpfsSpec, MonitoringSpec,
-            NetworkSpec, NetworkStatus, NetworkType, PodMonitorSpec, ResourceLimitsSpec,
-            RustIpfsSpec,
+            NetworkSpec, NetworkStatus, NetworkType, PersistentStorageSpec, PodMonitorSpec,
+            ResourceLimitsSpec, RustIpfsSpec,
         },
         utils::{
             test::{timeout_after_1s, ApiServerVerifier, WithStatus},
@@ -2384,6 +2384,10 @@ mod tests {
                             memory: Some(Quantity("4Gi".to_owned())),
                             storage: Some(Quantity("4Gi".to_owned())),
                         }),
+                        storage: Some(PersistentStorageSpec {
+                            size: Some(Quantity("1Gi".to_owned())),
+                            class: None,
+                        }),
                         ..Default::default()
                     })),
                     ..Default::default()
@@ -2512,6 +2516,15 @@ mod tests {
                            }
                          ]
                        }
+            @@ -470,7 +444,7 @@
+                           ],
+                           "resources": {
+                             "requests": {
+            -                  "storage": "10Gi"
+            +                  "storage": "1Gi"
+                             }
+                           }
+                         }
         "#]]);
         let (testctx, api_handle) = Context::test(mock_rpc_client);
         let fakeserver = ApiServerVerifier::new(api_handle);
@@ -2685,6 +2698,10 @@ mod tests {
                             memory: Some(Quantity("4Gi".to_owned())),
                             storage: Some(Quantity("4Gi".to_owned())),
                         }),
+                        storage: Some(PersistentStorageSpec {
+                            size: Some(Quantity("1Gi".to_owned())),
+                            class: Some("fastDisk".to_owned()),
+                        }),
                         env: Some(BTreeMap::from_iter([
                             ("ENV_KEY_A".to_string(), "ENV_VALUE_A".to_string()),
                             ("ENV_KEY_B".to_string(), "ENV_VALUE_B".to_string()),
@@ -2773,6 +2790,19 @@ mod tests {
                                }
                              },
                              "volumeMounts": [
+            @@ -470,9 +482,10 @@
+                           ],
+                           "resources": {
+                             "requests": {
+            -                  "storage": "10Gi"
+            +                  "storage": "1Gi"
+                             }
+            -              }
+            +              },
+            +              "storageClassName": "fastDisk"
+                         }
+                       },
+                       {
         "#]]);
         let (testctx, api_handle) = Context::test(mock_rpc_client);
         let fakeserver = ApiServerVerifier::new(api_handle);
@@ -2870,11 +2900,19 @@ mod tests {
                         memory: Some(Quantity("1Gi".to_owned())),
                         storage: Some(Quantity("1Gi".to_owned())),
                     }),
+                    cas_storage: Some(PersistentStorageSpec {
+                        size: Some(Quantity("2Gi".to_owned())),
+                        class: None,
+                    }),
                     ipfs: Some(IpfsSpec::Rust(RustIpfsSpec {
                         resource_limits: Some(ResourceLimitsSpec {
                             cpu: Some(Quantity("2".to_owned())),
                             memory: Some(Quantity("2Gi".to_owned())),
                             storage: Some(Quantity("2Gi".to_owned())),
+                        }),
+                        storage: Some(PersistentStorageSpec {
+                            size: Some(Quantity("3Gi".to_owned())),
+                            class: Some("fastDisk".to_owned()),
                         }),
                         ..Default::default()
                     })),
@@ -2883,10 +2921,18 @@ mod tests {
                         memory: Some(Quantity("3Gi".to_owned())),
                         storage: Some(Quantity("3Gi".to_owned())),
                     }),
+                    ganache_storage: Some(PersistentStorageSpec {
+                        size: Some(Quantity("4Gi".to_owned())),
+                        class: Some("fastDisk".to_owned()),
+                    }),
                     postgres_resource_limits: Some(ResourceLimitsSpec {
                         cpu: Some(Quantity("4".to_owned())),
                         memory: Some(Quantity("4Gi".to_owned())),
                         storage: Some(Quantity("4Gi".to_owned())),
+                    }),
+                    postgres_storage: Some(PersistentStorageSpec {
+                        size: Some(Quantity("5Gi".to_owned())),
+                        class: None,
                     }),
                     ..Default::default()
                 }),
@@ -2960,6 +3006,15 @@ mod tests {
                                  "ephemeral-storage": "1Gi",
                                  "memory": "1Gi"
                                }
+            @@ -470,7 +470,7 @@
+                           ],
+                           "resources": {
+                             "requests": {
+            -                  "storage": "10Gi"
+            +                  "storage": "2Gi"
+                             }
+                           }
+                         }
         "#]]);
         stub.cas_ipfs_stateful_set.patch(expect![[r#"
             --- original
@@ -2985,6 +3040,19 @@ mod tests {
                                }
                              },
                              "volumeMounts": [
+            @@ -136,9 +136,10 @@
+                           ],
+                           "resources": {
+                             "requests": {
+            -                  "storage": "10Gi"
+            +                  "storage": "3Gi"
+                             }
+            -              }
+            +              },
+            +              "storageClassName": "fastDisk"
+                         }
+                       }
+                     ]
         "#]]);
         stub.ganache_stateful_set.patch(expect![[r#"
             --- original
@@ -3010,6 +3078,19 @@ mod tests {
                                }
                              },
                              "volumeMounts": [
+            @@ -92,9 +92,10 @@
+                           ],
+                           "resources": {
+                             "requests": {
+            -                  "storage": "10Gi"
+            +                  "storage": "4Gi"
+                             }
+            -              }
+            +              },
+            +              "storageClassName": "fastDisk"
+                         }
+                       }
+                     ]
         "#]]);
         stub.cas_postgres_stateful_set.patch(expect![[r#"
             --- original
@@ -3035,6 +3116,15 @@ mod tests {
                                }
                              },
                              "volumeMounts": [
+            @@ -114,7 +114,7 @@
+                           ],
+                           "resources": {
+                             "requests": {
+            -                  "storage": "10Gi"
+            +                  "storage": "5Gi"
+                             }
+                           }
+                         }
         "#]]);
         let (testctx, api_handle) = Context::test(mock_rpc_client);
         let fakeserver = ApiServerVerifier::new(api_handle);
@@ -3054,6 +3144,10 @@ mod tests {
                         cpu: Some(Quantity("4".to_owned())),
                         memory: Some(Quantity("4Gi".to_owned())),
                         storage: Some(Quantity("4Gi".to_owned())),
+                    }),
+                    storage: Some(PersistentStorageSpec {
+                        size: Some(Quantity("100Gi".to_owned())),
+                        class: None,
                     }),
                     ..Default::default()
                 }]),
@@ -3124,6 +3218,15 @@ mod tests {
                                }
                              },
                              "volumeMounts": [
+            @@ -453,7 +453,7 @@
+                           ],
+                           "resources": {
+                             "requests": {
+            -                  "storage": "10Gi"
+            +                  "storage": "100Gi"
+                             }
+                           }
+                         }
         "#]]);
         let (testctx, api_handle) = Context::test(mock_rpc_client);
         let fakeserver = ApiServerVerifier::new(api_handle);

--- a/operator/src/network/mod.rs
+++ b/operator/src/network/mod.rs
@@ -25,6 +25,8 @@ mod node_affinity;
 pub(crate) mod peers;
 #[cfg(feature = "controller")]
 pub(crate) mod resource_limits;
+#[cfg(feature = "controller")]
+pub(crate) mod storage;
 
 #[cfg(test)]
 #[cfg(feature = "controller")]

--- a/operator/src/network/spec.rs
+++ b/operator/src/network/spec.rs
@@ -161,8 +161,12 @@ pub struct CeramicSpec {
     pub ipfs: Option<IpfsSpec>,
     /// Resource limits for ceramic nodes, applies to both requests and limits.
     pub resource_limits: Option<ResourceLimitsSpec>,
+    /// Storage configuration for the ceramic container.
+    pub storage: Option<PersistentStorageSpec>,
     /// Resource limits for postgres container in ceramic nodes, applies to both requests and limits.
     pub postgres_resource_limits: Option<ResourceLimitsSpec>,
+    /// Storage configuration for the postgres container.
+    pub postgres_storage: Option<PersistentStorageSpec>,
     /// Extra env values to pass to the image.
     /// CAUTION: Any env vars specified in this set will override any predefined values.
     pub env: Option<BTreeMap<String, String>>,
@@ -171,6 +175,9 @@ pub struct CeramicSpec {
 /// Describes how the IPFS node for a peer should behave.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+#[allow(clippy::large_enum_variant)]
+// Clippy seems be warning for a false positive.
+// It's saying 0 and at least 216, when it should be at least 248 for RustIpfsSpec.
 pub enum IpfsSpec {
     /// Rust IPFS specification
     Rust(RustIpfsSpec),
@@ -188,6 +195,8 @@ pub struct RustIpfsSpec {
     pub image_pull_policy: Option<String>,
     /// Resource limits for ipfs nodes, applies to both requests and limits.
     pub resource_limits: Option<ResourceLimitsSpec>,
+    /// Persistent storage configuration
+    pub storage: Option<PersistentStorageSpec>,
     /// Name of the storage class for the PVC of the IPFS container
     pub storage_class: Option<String>,
     /// Value of the RUST_LOG env var.
@@ -207,6 +216,8 @@ pub struct GoIpfsSpec {
     pub image_pull_policy: Option<String>,
     /// Resource limits for ipfs nodes, applies to both requests and limits.
     pub resource_limits: Option<ResourceLimitsSpec>,
+    /// Persistent storage configuration
+    pub storage: Option<PersistentStorageSpec>,
     /// Name of the storage class for the PVC of the IPFS container
     pub storage_class: Option<String>,
     /// List of ipfs commands to run during initialization.
@@ -225,14 +236,24 @@ pub struct CasSpec {
     pub ipfs: Option<IpfsSpec>,
     /// Resource limits for the CAS pod, applies to both requests and limits.
     pub cas_resource_limits: Option<ResourceLimitsSpec>,
+    /// CAS storage configuration
+    pub cas_storage: Option<PersistentStorageSpec>,
     /// Resource limits for the CAS IPFS pod, applies to both requests and limits.
     pub ipfs_resource_limits: Option<ResourceLimitsSpec>,
+    /// IPFS container storage configuration
+    pub ipfs_storage: Option<PersistentStorageSpec>,
     /// Resource limits for the Ganache pod, applies to both requests and limits.
     pub ganache_resource_limits: Option<ResourceLimitsSpec>,
+    /// Ganache container storage configuration
+    pub ganache_storage: Option<PersistentStorageSpec>,
     /// Resource limits for the CAS Postgres pod, applies to both requests and limits.
     pub postgres_resource_limits: Option<ResourceLimitsSpec>,
+    /// Postgres container container storage configuration
+    pub postgres_storage: Option<PersistentStorageSpec>,
     /// Resource limits for the LocalStack pod, applies to both requests and limits.
     pub localstack_resource_limits: Option<ResourceLimitsSpec>,
+    /// Localstack container storage configuration
+    pub localstack_storage: Option<PersistentStorageSpec>,
     /// Configuration for the CAS API
     pub api: Option<CasApiSpec>,
 }
@@ -268,6 +289,16 @@ pub struct ResourceLimitsSpec {
     pub memory: Option<Quantity>,
     /// Ephemeral storage resource limit
     pub storage: Option<Quantity>,
+}
+
+/// Describes the resources limits and requests for a pod
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistentStorageSpec {
+    /// Size of the persistent disk to request
+    pub size: Option<Quantity>,
+    /// Name of the storage class for the PVC of the container
+    pub class: Option<String>,
 }
 
 /// Describes how monitoring resources are deployed for the network

--- a/operator/src/network/storage.rs
+++ b/operator/src/network/storage.rs
@@ -1,0 +1,45 @@
+use std::collections::BTreeMap;
+
+use k8s_openapi::{
+    api::core::v1::{PersistentVolumeClaimSpec, ResourceRequirements},
+    apimachinery::pkg::api::resource::Quantity,
+};
+
+use crate::network::PersistentStorageSpec;
+
+#[derive(Clone)]
+pub struct PersistentStorageConfig {
+    /// Persistent storage resource limit
+    pub size: Quantity,
+    pub class: Option<String>,
+}
+
+impl PersistentStorageConfig {
+    pub fn from_spec(spec: Option<PersistentStorageSpec>, defaults: Self) -> Self {
+        if let Some(spec) = spec {
+            Self {
+                size: spec.size.unwrap_or(defaults.size),
+                class: spec.class.or(defaults.class),
+            }
+        } else {
+            defaults
+        }
+    }
+}
+
+impl From<PersistentStorageConfig> for PersistentVolumeClaimSpec {
+    fn from(value: PersistentStorageConfig) -> Self {
+        Self {
+            access_modes: Some(vec!["ReadWriteOnce".to_owned()]),
+            resources: Some(ResourceRequirements {
+                requests: Some(BTreeMap::from_iter(vec![(
+                    "storage".to_owned(),
+                    value.size,
+                )])),
+                ..Default::default()
+            }),
+            storage_class_name: value.class,
+            ..Default::default()
+        }
+    }
+}


### PR DESCRIPTION
Add persistent storage config object that allows modifying the persistent volume storage size and class. I updated a handful of tests to set this, so we see the 10 -> override value, demonstrating that the default is still 10 (and shown in tests that haven't been updated). If preferable, I can write dedicated tests for this new setting.

For IPFS, we allowed specifying `storageClass` before. We still support this field, but will prefer the `storage.class` field if it is set. If not, we will use `storageClass` (there are existing tests that demonstrate this).