### PR TITLE
fix: use different aws region for cas than us-east-1

### DIFF
--- a/operator/src/network/cas.rs
+++ b/operator/src/network/cas.rs
@@ -202,7 +202,7 @@ pub fn cas_stateful_set_spec(
         },
         EnvVar {
             name: "AWS_REGION".to_owned(),
-            value: Some("us-east-1".to_owned()),
+            value: Some("us-east-2".to_owned()),
             ..Default::default()
         },
         EnvVar {
@@ -268,11 +268,6 @@ pub fn cas_stateful_set_spec(
             EnvVar {
                 name: "MERKLE_CAR_STORAGE_MODE".to_owned(),
                 value: Some("s3".to_owned()),
-                ..Default::default()
-            },
-            EnvVar {
-                name: "S3_BUCKET_NAME".to_owned(),
-                value: Some("merkle-car".to_owned()),
                 ..Default::default()
             },
             EnvVar {
@@ -361,26 +356,6 @@ pub fn cas_stateful_set_spec(
                         image: Some(config.image.clone()),
                         image_pull_policy: Some(config.image_pull_policy.clone()),
                         name: "cas-migrations".to_owned(),
-                        ..Default::default()
-                    },
-                    Container {
-                        env: Some(aws_env.clone()),
-                        command: Some(
-                            [
-                                "aws",
-                                "s3api",
-                                "create-bucket",
-                                "--bucket",
-                                "merkle-car",
-                                "--endpoint-url",
-                                "http://localstack:4566",
-                            ]
-                            .map(String::from)
-                            .to_vec(),
-                        ),
-                        image: Some("amazon/aws-cli".to_owned()),
-                        image_pull_policy: Some("IfNotPresent".to_owned()),
-                        name: "aws-cli".to_owned(),
                         ..Default::default()
                     },
                 ]),
@@ -868,7 +843,7 @@ pub fn localstack_stateful_set_spec(
             }),
             spec: Some(PodSpec {
                 containers: vec![Container {
-                    image: Some("gresau/localstack-persist:2".to_owned()),
+                    image: Some("gresau/localstack-persist:3".to_owned()),
                     image_pull_policy: Some("IfNotPresent".to_owned()),
                     name: "localstack".to_owned(),
                     ports: Some(vec![ContainerPort {

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -2817,7 +2817,7 @@ mod tests {
         stub.cas_stateful_set.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -134,8 +134,8 @@
+            @@ -130,8 +130,8 @@
                                  "value": "http://localstack:4566/000000000000/cas-anchor-dev-"
                                }
                              ],
@@ -2828,7 +2828,7 @@ mod tests {
                              "name": "cas-api",
                              "ports": [
                                {
-            @@ -272,8 +272,8 @@
+            @@ -264,8 +264,8 @@
                                  "value": "false"
                                }
                              ],
@@ -2839,7 +2839,7 @@ mod tests {
                              "name": "cas-worker",
                              "resources": {
                                "limits": {
-            @@ -442,8 +442,8 @@
+            @@ -434,8 +434,8 @@
                                  "value": "dev"
                                }
                              ],
@@ -2848,8 +2848,8 @@ mod tests {
             +                "image": "cas/cas:dev",
             +                "imagePullPolicy": "Never",
                              "name": "cas-migrations"
-                           },
-                           {
+                           }
+                         ],
         "#]]);
         let (testctx, api_handle) = Context::test(mock_rpc_client);
         let fakeserver = ApiServerVerifier::new(api_handle);
@@ -2915,7 +2915,7 @@ mod tests {
         stub.cas_stateful_set.patch(expect![[r#"
             --- original
             +++ modified
-            @@ -144,12 +144,12 @@
+            @@ -140,12 +140,12 @@
                              ],
                              "resources": {
                                "limits": {
@@ -2930,7 +2930,7 @@ mod tests {
                                  "ephemeral-storage": "1Gi",
                                  "memory": "1Gi"
                                }
-            @@ -277,12 +277,12 @@
+            @@ -269,12 +269,12 @@
                              "name": "cas-worker",
                              "resources": {
                                "limits": {
@@ -2945,7 +2945,7 @@ mod tests {
                                  "ephemeral-storage": "1Gi",
                                  "memory": "1Gi"
                                }
-            @@ -365,12 +365,12 @@
+            @@ -357,12 +357,12 @@
                              "name": "cas-scheduler",
                              "resources": {
                                "limits": {
@@ -4352,7 +4352,7 @@ mod tests {
             +            },
                          "containers": [
                            {
-                             "image": "gresau/localstack-persist:2",
+                             "image": "gresau/localstack-persist:3",
         "#]]);
 
         stub.ceramics[0].stateful_set.patch(expect![[r#"

--- a/operator/src/network/testdata/default_stubs/cas_stateful_set
+++ b/operator/src/network/testdata/default_stubs/cas_stateful_set
@@ -53,7 +53,7 @@ Request {
                   },
                   {
                     "name": "AWS_REGION",
-                    "value": "us-east-1"
+                    "value": "us-east-2"
                   },
                   {
                     "name": "AWS_SECRET_ACCESS_KEY",
@@ -122,10 +122,6 @@ Request {
                     "value": "dev"
                   },
                   {
-                    "name": "S3_BUCKET_NAME",
-                    "value": "merkle-car"
-                  },
-                  {
                     "name": "S3_ENDPOINT",
                     "value": "http://localstack:4566"
                   },
@@ -189,7 +185,7 @@ Request {
                   },
                   {
                     "name": "AWS_REGION",
-                    "value": "us-east-1"
+                    "value": "us-east-2"
                   },
                   {
                     "name": "AWS_ACCESS_KEY_ID",
@@ -234,10 +230,6 @@ Request {
                   {
                     "name": "MERKLE_CAR_STORAGE_MODE",
                     "value": "s3"
-                  },
-                  {
-                    "name": "S3_BUCKET_NAME",
-                    "value": "merkle-car"
                   },
                   {
                     "name": "S3_ENDPOINT",
@@ -322,7 +314,7 @@ Request {
                   },
                   {
                     "name": "AWS_REGION",
-                    "value": "us-east-1"
+                    "value": "us-east-2"
                   },
                   {
                     "name": "AWS_ACCESS_KEY_ID",
@@ -445,42 +437,6 @@ Request {
                 "image": "ceramicnetwork/ceramic-anchor-service:latest",
                 "imagePullPolicy": "Always",
                 "name": "cas-migrations"
-              },
-              {
-                "command": [
-                  "aws",
-                  "s3api",
-                  "create-bucket",
-                  "--bucket",
-                  "merkle-car",
-                  "--endpoint-url",
-                  "http://localstack:4566"
-                ],
-                "env": [
-                  {
-                    "name": "AWS_ACCOUNT_ID",
-                    "value": "000000000000"
-                  },
-                  {
-                    "name": "AWS_REGION",
-                    "value": "us-east-1"
-                  },
-                  {
-                    "name": "AWS_ACCESS_KEY_ID",
-                    "value": "."
-                  },
-                  {
-                    "name": "AWS_SECRET_ACCESS_KEY",
-                    "value": "."
-                  },
-                  {
-                    "name": "SQS_QUEUE_URL",
-                    "value": "http://localstack:4566/000000000000/cas-anchor-dev-"
-                  }
-                ],
-                "image": "amazon/aws-cli",
-                "imagePullPolicy": "IfNotPresent",
-                "name": "aws-cli"
               }
             ],
             "volumes": [

--- a/operator/src/network/testdata/default_stubs/localstack_stateful_set
+++ b/operator/src/network/testdata/default_stubs/localstack_stateful_set
@@ -32,7 +32,7 @@ Request {
           "spec": {
             "containers": [
               {
-                "image": "gresau/localstack-persist:2",
+                "image": "gresau/localstack-persist:3",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "localstack",
                 "ports": [


### PR DESCRIPTION
The CAS Scheduler specifies a location constraint when creating a S3 bucket. `us-east-1` is not a valid option when specifying the region.