### PR TITLE
chore: update js-ceramic healthcheck timing

### DIFF
--- a/operator/src/network/ceramic.rs
+++ b/operator/src/network/ceramic.rs
@@ -560,9 +560,9 @@ pub fn stateful_set_spec(ns: &str, bundle: &CeramicBundle<'_>) -> StatefulSetSpe
                                     port: IntOrString::String("api".to_owned()),
                                     ..Default::default()
                                 }),
-                                initial_delay_seconds: Some(60),
-                                period_seconds: Some(15),
-                                timeout_seconds: Some(30),
+                                initial_delay_seconds: Some(15),
+                                period_seconds: Some(30),
+                                timeout_seconds: Some(60),
                                 ..Default::default()
                             }),
                             liveness_probe: Some(Probe {
@@ -571,9 +571,9 @@ pub fn stateful_set_spec(ns: &str, bundle: &CeramicBundle<'_>) -> StatefulSetSpe
                                     port: IntOrString::String("api".to_owned()),
                                     ..Default::default()
                                 }),
-                                initial_delay_seconds: Some(60),
-                                period_seconds: Some(15),
-                                timeout_seconds: Some(30),
+                                initial_delay_seconds: Some(15),
+                                period_seconds: Some(30),
+                                timeout_seconds: Some(120),
                                 ..Default::default()
                             }),
                             resources: Some(ResourceRequirements {

--- a/operator/src/network/testdata/ceramic_go_ss_1
+++ b/operator/src/network/testdata/ceramic_go_ss_1
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {

--- a/operator/src/network/testdata/ceramic_ss_1
+++ b/operator/src/network/testdata/ceramic_ss_1
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_0
+++ b/operator/src/network/testdata/ceramic_ss_weighted_0
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_1
+++ b/operator/src/network/testdata/ceramic_ss_weighted_1
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_2
+++ b/operator/src/network/testdata/ceramic_ss_weighted_2
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_3
+++ b/operator/src/network/testdata/ceramic_ss_weighted_3
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_4
+++ b/operator/src/network/testdata/ceramic_ss_weighted_4
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_5
+++ b/operator/src/network/testdata/ceramic_ss_weighted_5
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_6
+++ b/operator/src/network/testdata/ceramic_ss_weighted_6
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_7
+++ b/operator/src/network/testdata/ceramic_ss_weighted_7
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_8
+++ b/operator/src/network/testdata/ceramic_ss_weighted_8
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_9
+++ b/operator/src/network/testdata/ceramic_ss_weighted_9
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {

--- a/operator/src/network/testdata/default_stubs/ceramic_stateful_set
+++ b/operator/src/network/testdata/default_stubs/ceramic_stateful_set
@@ -111,9 +111,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 120
                 },
                 "name": "ceramic",
                 "ports": [
@@ -132,9 +132,9 @@ Request {
                     "path": "/api/v0/node/healthcheck",
                     "port": "api"
                   },
-                  "initialDelaySeconds": 60,
-                  "periodSeconds": 15,
-                  "timeoutSeconds": 30
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 30,
+                  "timeoutSeconds": 60
                 },
                 "resources": {
                   "limits": {


### PR DESCRIPTION
- lower initial_delay_seconds so that healthchecks are run faster and pods are marked up earlier
- lower period_seconds so that there are less healthchecks (already enough load on the system!)
- increase timeout_seconds as the js-ceramic health check makes its own external calls to "ipfs" which where longer than this setting
