### PR TITLE
chore: update ceramic http client and fix recon sync test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,11 +703,10 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.18.0"
-source = "git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main#c803ac49ec7b136a3aca42927c5696649238841a"
+version = "0.24.0"
+source = "git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main#8333cc9021f54bab1b941712fce5e2fdae60787a"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64 0.21.7",
  "cid 0.11.1",
  "did-method-key",
@@ -731,23 +730,28 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.18.0"
-source = "git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main#c803ac49ec7b136a3aca42927c5696649238841a"
+version = "0.24.0"
+source = "git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main#8333cc9021f54bab1b941712fce5e2fdae60787a"
 dependencies = [
  "anyhow",
- "async-trait",
+ "base64 0.21.7",
  "ceramic-core",
  "cid 0.11.1",
  "ipld-core",
+ "iroh-car",
  "multihash-codetable",
  "serde",
+ "serde_ipld_dagcbor",
  "serde_json",
+ "ssi",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "ceramic-http-client"
 version = "0.1.0"
-source = "git+https://github.com/3box/ceramic-http-client-rs.git?branch=main#ffa148277f686b694100430f0125e65169c9f548"
+source = "git+https://github.com/3box/ceramic-http-client-rs.git?branch=main#536203fb3c71ab2cc1f73e70bb838b372ef12453"
 dependencies = [
  "anyhow",
  "ceramic-event",
@@ -2456,8 +2460,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-car"
-version = "0.18.0"
-source = "git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main#c803ac49ec7b136a3aca42927c5696649238841a"
+version = "0.24.0"
+source = "git+https://github.com/ceramicnetwork/rust-ceramic.git?branch=main#8333cc9021f54bab1b941712fce5e2fdae60787a"
 dependencies = [
  "cid 0.11.1",
  "futures",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -11,7 +11,6 @@ async-trait.workspace = true
 ceramic-core.workspace = true
 iroh-car.workspace = true
 ceramic-http-client = { git = "https://github.com/3box/ceramic-http-client-rs.git", branch = "main", default-features = false }
-#ceramic-http-client = { path = "../../ceramic-http-client-rs", default-features = false }
 clap.workspace = true
 did-method-key = "0.2"
 goose = { version = "0.16", features = ["gaggle"] }
@@ -25,7 +24,7 @@ opentelemetry.workspace = true
 rand = "0.8.5"
 redis = { version = "0.24", features = ["tokio-comp"] }
 reqwest.workspace = true
-serde = { version = "1.0", features = ["derive"] } 
+serde = { version = "1.0", features = ["derive"] }
 serde_ipld_dagcbor = "0.6"
 serde_ipld_dagjson = "0.2"
 schemars.workspace = true

--- a/runner/src/scenario/ceramic/mod.rs
+++ b/runner/src/scenario/ceramic/mod.rs
@@ -8,7 +8,7 @@ pub mod write_only;
 
 use ceramic_core::ssi::did::{DIDMethod, Document, DocumentBuilder, Source};
 use ceramic_core::ssi::jwk::{self, Base64urlUInt, Params, JWK};
-use ceramic_http_client::ceramic_event::JwkSigner;
+use ceramic_http_client::ceramic_event::unvalidated::signed::JwkSigner;
 use ceramic_http_client::CeramicHttpClient;
 
 use models::RandomModelInstance;

--- a/runner/src/scenario/ceramic/model_instance.rs
+++ b/runner/src/scenario/ceramic/model_instance.rs
@@ -688,7 +688,6 @@ impl ModelInstanceRequests {
         let name = format!("create_index_model_{}", tx_name);
         let req = cli
             .create_index_model_request(model_id, &resp.code)
-            .await
             .unwrap();
         let mut goose = user
             .request(

--- a/runner/src/scenario/recon_sync.rs
+++ b/runner/src/scenario/recon_sync.rs
@@ -120,17 +120,17 @@ async fn create_new_event(user: &mut GooseUser) -> TransactionResult {
         let user_data: &ReconCeramicModelInstanceTestUser = user
             .get_session_data()
             .expect("we are missing sync_event_id user data");
-        let data = random_init_event_car(
-            SORT_KEY,
-            user_data.model_id.to_vec().unwrap(),
+        let event = random_init_event_car(
+            user_data.model_id.to_vec(),
             Some(TEST_CONTROLLER.to_string()),
         )
         .await
         .unwrap();
-        let event_key_body = serde_json::json!({"data": data});
         // eventId needs to be a multibase encoded string for the API to accept it
-
         let cnt = NEW_EVENT_CNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let event_key_body = serde_json::json!({
+            "data": event,
+        });
 
         if cnt == 0 || cnt % 1000 == 0 {
             tracing::trace!("new sync_event_id body: {:?}", event_key_body);
@@ -150,7 +150,6 @@ async fn create_new_event(user: &mut GooseUser) -> TransactionResult {
     }
 }
 
-const SORT_KEY: &str = "model";
 // hard code test controller in case we want to find/prune later
 const TEST_CONTROLLER: &str = "did:key:z6MkoFUppcKEVYTS8oVidrja94UoJTatNhnhxJRKF7NYPScS";
 


### PR DESCRIPTION
Updates the `ceramic-http-client-rs` dependency and uses the new event format from rust ceramic. This allows the `recon-event-sync` scenario to work without failing due "unexpected fields" when the API roundtrips the payload to make sure it is as expected.