### PR TITLE
feat: make anchoring fast by default

### DIFF
--- a/operator/src/network/cas.rs
+++ b/operator/src/network/cas.rs
@@ -454,6 +454,11 @@ pub fn cas_stateful_set_spec(
                                         value: Some("false".to_owned()),
                                         ..Default::default()
                                     },
+                                    EnvVar {
+                                        name: "SCHEDULER_INTERVAL_MS".to_owned(),
+                                        value: Some("1000".to_owned()),
+                                        ..Default::default()
+                                    },
                                 ],
                             ]
                             .concat(),
@@ -648,7 +653,7 @@ pub fn ganache_stateful_set_spec(
                     command: Some([
                         "node",
                         "/app/dist/node/cli.js",
-                        "--miner.blockTime=5",
+                        "--miner.blockTime=0",
                         "--mnemonic='move sense much taxi wave hurry recall stairs thank brother nut woman'",
                         "--networkId=5777",
                         "-l=80000000",

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -2858,8 +2858,8 @@ mod tests {
                              "name": "cas-api",
                              "ports": [
                                {
-            @@ -272,8 +272,8 @@
-                                 "value": "false"
+            @@ -276,8 +276,8 @@
+                                 "value": "1000"
                                }
                              ],
             -                "image": "ceramicnetwork/ceramic-anchor-service:latest",
@@ -2869,7 +2869,7 @@ mod tests {
                              "name": "cas-worker",
                              "resources": {
                                "limits": {
-            @@ -442,8 +442,8 @@
+            @@ -446,8 +446,8 @@
                                  "value": "dev"
                                }
                              ],
@@ -2976,7 +2976,7 @@ mod tests {
                                  "ephemeral-storage": "1Gi",
                                  "memory": "1Gi"
                                }
-            @@ -277,12 +277,12 @@
+            @@ -281,12 +281,12 @@
                              "name": "cas-worker",
                              "resources": {
                                "limits": {
@@ -2991,7 +2991,7 @@ mod tests {
                                  "ephemeral-storage": "1Gi",
                                  "memory": "1Gi"
                                }
-            @@ -365,12 +365,12 @@
+            @@ -369,12 +369,12 @@
                              "name": "cas-scheduler",
                              "resources": {
                                "limits": {
@@ -3006,7 +3006,7 @@ mod tests {
                                  "ephemeral-storage": "1Gi",
                                  "memory": "1Gi"
                                }
-            @@ -470,7 +470,7 @@
+            @@ -474,7 +474,7 @@
                            ],
                            "resources": {
                              "requests": {

--- a/operator/src/network/testdata/default_stubs/cas_stateful_set
+++ b/operator/src/network/testdata/default_stubs/cas_stateful_set
@@ -270,6 +270,10 @@ Request {
                   {
                     "name": "SCHEDULER_STOP_AFTER_NO_OP",
                     "value": "false"
+                  },
+                  {
+                    "name": "SCHEDULER_INTERVAL_MS",
+                    "value": "1000"
                   }
                 ],
                 "image": "ceramicnetwork/ceramic-anchor-service:latest",

--- a/operator/src/network/testdata/default_stubs/ganache_stateful_set
+++ b/operator/src/network/testdata/default_stubs/ganache_stateful_set
@@ -35,7 +35,7 @@ Request {
                 "command": [
                   "node",
                   "/app/dist/node/cli.js",
-                  "--miner.blockTime=5",
+                  "--miner.blockTime=0",
                   "--mnemonic='move sense much taxi wave hurry recall stairs thank brother nut woman'",
                   "--networkId=5777",
                   "-l=80000000",


### PR DESCRIPTION
When keramik is used to deploy CAS it is only in the context of a hermetic testing env. Therefore we can assume that anchoring should be as fast as possible in order to all for faster tests etc.

Makes two changes:

1. Reduces worker delay to 1s instead of 1m after completing a batch.
2. Configures ganache to instantly mine any transaction.