### PR TITLE
fix: use smallest time for block time

### DIFF
--- a/operator/src/network/cas.rs
+++ b/operator/src/network/cas.rs
@@ -654,11 +654,11 @@ pub fn ganache_stateful_set_spec(
                     command: Some([
                         "node",
                         "/app/dist/node/cli.js",
-                        "--miner.blockTime=0",
+                        "--miner.blockTime=1",
                         "--mnemonic='move sense much taxi wave hurry recall stairs thank brother nut woman'",
                         "--networkId=5777",
                         "-l=80000000",
-                        "--quiet",
+                        "-v",
                     ].map(String::from).to_vec()),
                     image: Some("trufflesuite/ganache".to_owned()),
                     image_pull_policy: Some("IfNotPresent".to_owned()),

--- a/operator/src/network/testdata/default_stubs/ganache_stateful_set
+++ b/operator/src/network/testdata/default_stubs/ganache_stateful_set
@@ -35,11 +35,11 @@ Request {
                 "command": [
                   "node",
                   "/app/dist/node/cli.js",
-                  "--miner.blockTime=0",
+                  "--miner.blockTime=1",
                   "--mnemonic='move sense much taxi wave hurry recall stairs thank brother nut woman'",
                   "--networkId=5777",
                   "-l=80000000",
-                  "--quiet"
+                  "-v"
                 ],
                 "image": "trufflesuite/ganache",
                 "imagePullPolicy": "IfNotPresent",


### PR DESCRIPTION
Using the instamine option of ganache confuses the CAS worker and it waits forever to see the transaction has been mined. This change uses a block time of 1 second, however in practice this appears to mean a block every 15 seconds. Faster than once a minute but still not very fast.