### PR TITLE
fix: set kubo API port to 5101

### DIFF
--- a/operator/src/network/ipfs.rs
+++ b/operator/src/network/ipfs.rs
@@ -364,6 +364,7 @@ ipfs config  --json Addresses.Gateway '[]'
 ipfs config  --json PubSub.Enabled true
 # Only listen on specific tcp address as nothing else is exposed
 ipfs config  --json Addresses.Swarm '["/ip4/0.0.0.0/tcp/4101"]'
+ipfs config  --json Addresses.API '["/ip4/0.0.0.0/tcp/5101"]'
 # Set explicit resource manager limits as Kubo computes them based off
 # the k8s node resources and not the pods limits.
 ipfs config Swarm.ResourceMgr.MaxMemory '400 MB'

--- a/operator/src/network/testdata/go_ipfs_configmap
+++ b/operator/src/network/testdata/go_ipfs_configmap
@@ -8,7 +8,7 @@ Request {
     body: {
       "apiVersion": "v1",
       "data": {
-        "001-config.sh": "#!/bin/sh\nset -ex\n# Do not bootstrap against public nodes\nipfs bootstrap rm all\n# Do not sticky peer with ceramic specific peers\n# We want an isolated network\nipfs config --json Peering.Peers '[]'\n# Disable the gateway\nipfs config  --json Addresses.Gateway '[]'\n# Enable pubsub\nipfs config  --json PubSub.Enabled true\n# Only listen on specific tcp address as nothing else is exposed\nipfs config  --json Addresses.Swarm '[\"/ip4/0.0.0.0/tcp/4101\"]'\n# Set explicit resource manager limits as Kubo computes them based off\n# the k8s node resources and not the pods limits.\nipfs config Swarm.ResourceMgr.MaxMemory '400 MB'\nipfs config --json Swarm.ResourceMgr.MaxFileDescriptors 500000\n"
+        "001-config.sh": "#!/bin/sh\nset -ex\n# Do not bootstrap against public nodes\nipfs bootstrap rm all\n# Do not sticky peer with ceramic specific peers\n# We want an isolated network\nipfs config --json Peering.Peers '[]'\n# Disable the gateway\nipfs config  --json Addresses.Gateway '[]'\n# Enable pubsub\nipfs config  --json PubSub.Enabled true\n# Only listen on specific tcp address as nothing else is exposed\nipfs config  --json Addresses.Swarm '[\"/ip4/0.0.0.0/tcp/4101\"]'\nipfs config  --json Addresses.API '[\"/ip4/0.0.0.0/tcp/5101\"]'\n# Set explicit resource manager limits as Kubo computes them based off\n# the k8s node resources and not the pods limits.\nipfs config Swarm.ResourceMgr.MaxMemory '400 MB'\nipfs config --json Swarm.ResourceMgr.MaxFileDescriptors 500000\n"
       },
       "kind": "ConfigMap",
       "metadata": {

--- a/operator/src/network/testdata/go_ipfs_configmap_1
+++ b/operator/src/network/testdata/go_ipfs_configmap_1
@@ -8,7 +8,7 @@ Request {
     body: {
       "apiVersion": "v1",
       "data": {
-        "001-config.sh": "#!/bin/sh\nset -ex\n# Do not bootstrap against public nodes\nipfs bootstrap rm all\n# Do not sticky peer with ceramic specific peers\n# We want an isolated network\nipfs config --json Peering.Peers '[]'\n# Disable the gateway\nipfs config  --json Addresses.Gateway '[]'\n# Enable pubsub\nipfs config  --json PubSub.Enabled true\n# Only listen on specific tcp address as nothing else is exposed\nipfs config  --json Addresses.Swarm '[\"/ip4/0.0.0.0/tcp/4101\"]'\n# Set explicit resource manager limits as Kubo computes them based off\n# the k8s node resources and not the pods limits.\nipfs config Swarm.ResourceMgr.MaxMemory '400 MB'\nipfs config --json Swarm.ResourceMgr.MaxFileDescriptors 500000\n"
+        "001-config.sh": "#!/bin/sh\nset -ex\n# Do not bootstrap against public nodes\nipfs bootstrap rm all\n# Do not sticky peer with ceramic specific peers\n# We want an isolated network\nipfs config --json Peering.Peers '[]'\n# Disable the gateway\nipfs config  --json Addresses.Gateway '[]'\n# Enable pubsub\nipfs config  --json PubSub.Enabled true\n# Only listen on specific tcp address as nothing else is exposed\nipfs config  --json Addresses.Swarm '[\"/ip4/0.0.0.0/tcp/4101\"]'\nipfs config  --json Addresses.API '[\"/ip4/0.0.0.0/tcp/5101\"]'\n# Set explicit resource manager limits as Kubo computes them based off\n# the k8s node resources and not the pods limits.\nipfs config Swarm.ResourceMgr.MaxMemory '400 MB'\nipfs config --json Swarm.ResourceMgr.MaxFileDescriptors 500000\n"
       },
       "kind": "ConfigMap",
       "metadata": {

--- a/operator/src/network/testdata/go_ipfs_configmap_commands
+++ b/operator/src/network/testdata/go_ipfs_configmap_commands
@@ -8,7 +8,7 @@ Request {
     body: {
       "apiVersion": "v1",
       "data": {
-        "001-config.sh": "#!/bin/sh\nset -ex\n# Do not bootstrap against public nodes\nipfs bootstrap rm all\n# Do not sticky peer with ceramic specific peers\n# We want an isolated network\nipfs config --json Peering.Peers '[]'\n# Disable the gateway\nipfs config  --json Addresses.Gateway '[]'\n# Enable pubsub\nipfs config  --json PubSub.Enabled true\n# Only listen on specific tcp address as nothing else is exposed\nipfs config  --json Addresses.Swarm '[\"/ip4/0.0.0.0/tcp/4101\"]'\n# Set explicit resource manager limits as Kubo computes them based off\n# the k8s node resources and not the pods limits.\nipfs config Swarm.ResourceMgr.MaxMemory '400 MB'\nipfs config --json Swarm.ResourceMgr.MaxFileDescriptors 500000\n",
+        "001-config.sh": "#!/bin/sh\nset -ex\n# Do not bootstrap against public nodes\nipfs bootstrap rm all\n# Do not sticky peer with ceramic specific peers\n# We want an isolated network\nipfs config --json Peering.Peers '[]'\n# Disable the gateway\nipfs config  --json Addresses.Gateway '[]'\n# Enable pubsub\nipfs config  --json PubSub.Enabled true\n# Only listen on specific tcp address as nothing else is exposed\nipfs config  --json Addresses.Swarm '[\"/ip4/0.0.0.0/tcp/4101\"]'\nipfs config  --json Addresses.API '[\"/ip4/0.0.0.0/tcp/5101\"]'\n# Set explicit resource manager limits as Kubo computes them based off\n# the k8s node resources and not the pods limits.\nipfs config Swarm.ResourceMgr.MaxMemory '400 MB'\nipfs config --json Swarm.ResourceMgr.MaxFileDescriptors 500000\n",
         "002-config.sh": "#!/bin/sh\nset -ex\nipfs config Pubsub.SeenMessagesTTL 10m\nipfs config --json Swarm.RelayClient.Enabled false"
       },
       "kind": "ConfigMap",


### PR DESCRIPTION
We need to override the kubo API port at start up to match the port we're opening on the container.