### PR TITLE
fix: use cas develop image by default

### DIFF
--- a/operator/src/network/cas.rs
+++ b/operator/src/network/cas.rs
@@ -83,7 +83,7 @@ impl CasConfig {
 impl Default for CasConfig {
     fn default() -> Self {
         Self {
-            image: "ceramicnetwork/ceramic-anchor-service:latest".to_owned(),
+            image: "ceramicnetwork/ceramic-anchor-service:develop".to_owned(),
             image_pull_policy: "Always".to_owned(),
             cas_resource_limits: ResourceLimitsConfig {
                 cpu: Some(Quantity("250m".to_owned())),

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -2852,7 +2852,7 @@ mod tests {
                                  "value": "http://localstack:4566/000000000000/cas-anchor-dev-"
                                }
                              ],
-            -                "image": "ceramicnetwork/ceramic-anchor-service:latest",
+            -                "image": "ceramicnetwork/ceramic-anchor-service:develop",
             -                "imagePullPolicy": "Always",
             +                "image": "cas/cas:dev",
             +                "imagePullPolicy": "Never",
@@ -2863,7 +2863,7 @@ mod tests {
                                  "value": "1000"
                                }
                              ],
-            -                "image": "ceramicnetwork/ceramic-anchor-service:latest",
+            -                "image": "ceramicnetwork/ceramic-anchor-service:develop",
             -                "imagePullPolicy": "Always",
             +                "image": "cas/cas:dev",
             +                "imagePullPolicy": "Never",
@@ -2874,7 +2874,7 @@ mod tests {
                                  "value": "dev"
                                }
                              ],
-            -                "image": "ceramicnetwork/ceramic-anchor-service:latest",
+            -                "image": "ceramicnetwork/ceramic-anchor-service:develop",
             -                "imagePullPolicy": "Always",
             +                "image": "cas/cas:dev",
             +                "imagePullPolicy": "Never",

--- a/operator/src/network/testdata/default_stubs/cas_stateful_set
+++ b/operator/src/network/testdata/default_stubs/cas_stateful_set
@@ -138,7 +138,7 @@ Request {
                     "value": "http://localstack:4566/000000000000/cas-anchor-dev-"
                   }
                 ],
-                "image": "ceramicnetwork/ceramic-anchor-service:latest",
+                "image": "ceramicnetwork/ceramic-anchor-service:develop",
                 "imagePullPolicy": "Always",
                 "name": "cas-api",
                 "ports": [
@@ -280,7 +280,7 @@ Request {
                     "value": "1000"
                   }
                 ],
-                "image": "ceramicnetwork/ceramic-anchor-service:latest",
+                "image": "ceramicnetwork/ceramic-anchor-service:develop",
                 "imagePullPolicy": "Always",
                 "name": "cas-worker",
                 "resources": {
@@ -450,7 +450,7 @@ Request {
                     "value": "dev"
                   }
                 ],
-                "image": "ceramicnetwork/ceramic-anchor-service:latest",
+                "image": "ceramicnetwork/ceramic-anchor-service:develop",
                 "imagePullPolicy": "Always",
                 "name": "cas-migrations"
               }


### PR DESCRIPTION
Need CAS API changes currently in develop, but also probably a good idea to use the develop image in general.