### PR TITLE
fix: use composedb develop image by default

### DIFF
--- a/local-scripts/load.py
+++ b/local-scripts/load.py
@@ -2,11 +2,11 @@ import subprocess
 
 images = [
         'amazon/aws-cli',
-        'ceramicnetwork/ceramic-anchor-service:latest',
-        'ceramicnetwork/composedb:latest',
-        'gresau/localstack-persist:2',
-        'public.ecr.aws/r5b3e0r5/3box/cas-contract',
-        'public.ecr.aws/r5b3e0r5/3box/ceramic-one',
+        'ceramicnetwork/ceramic-anchor-service:develop',
+        'ceramicnetwork/composedb:develop',
+        'gresau/localstack-persist:3',
+        'public.ecr.aws/r5b3e0r5/3box/cas-contract:latest',
+        'public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest',
         'public.ecr.aws/r5b3e0r5/3box/go-cas:latest',
         'trufflesuite/ganache'
         ]

--- a/operator/src/network/ceramic.rs
+++ b/operator/src/network/ceramic.rs
@@ -264,7 +264,7 @@ impl Default for CeramicConfig {
         Self {
             weight: 1,
             init_config_map: INIT_CONFIG_MAP_NAME.to_owned(),
-            image: "ceramicnetwork/composedb:latest".to_owned(),
+            image: "ceramicnetwork/composedb:develop".to_owned(),
             image_pull_policy: "Always".to_owned(),
             init_image_name: "ceramicnetwork/composedb-cli:latest".to_owned(),
             ipfs: IpfsConfig::default(),

--- a/operator/src/network/controller.rs
+++ b/operator/src/network/controller.rs
@@ -3492,7 +3492,7 @@ mod tests {
                                  }
                                }
                              ],
-            -                "image": "ceramicnetwork/composedb:latest",
+            -                "image": "ceramicnetwork/composedb:develop",
             -                "imagePullPolicy": "Always",
             +                "image": "ceramic:foo",
             +                "imagePullPolicy": "IfNotPresent",
@@ -3573,7 +3573,7 @@ mod tests {
             +                    "value": "true"
                                }
                              ],
-                             "image": "ceramicnetwork/composedb:latest",
+                             "image": "ceramicnetwork/composedb:develop",
         "#]]);
         stub.cas_stateful_set.patch(expect![[r#"
             --- original
@@ -3913,7 +3913,7 @@ mod tests {
             +                    "value": "SOME_ENV_VALUE"
                                }
                              ],
-                             "image": "ceramicnetwork/composedb:latest",
+                             "image": "ceramicnetwork/composedb:develop",
             @@ -374,6 +378,10 @@
                                      "name": "ceramic-postgres-auth"
                                    }

--- a/operator/src/network/testdata/ceramic_go_ss_1
+++ b/operator/src/network/testdata/ceramic_go_ss_1
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {

--- a/operator/src/network/testdata/ceramic_ss_1
+++ b/operator/src/network/testdata/ceramic_ss_1
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_0
+++ b/operator/src/network/testdata/ceramic_ss_weighted_0
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_1
+++ b/operator/src/network/testdata/ceramic_ss_weighted_1
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_2
+++ b/operator/src/network/testdata/ceramic_ss_weighted_2
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_3
+++ b/operator/src/network/testdata/ceramic_ss_weighted_3
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_4
+++ b/operator/src/network/testdata/ceramic_ss_weighted_4
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_5
+++ b/operator/src/network/testdata/ceramic_ss_weighted_5
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_6
+++ b/operator/src/network/testdata/ceramic_ss_weighted_6
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_7
+++ b/operator/src/network/testdata/ceramic_ss_weighted_7
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_8
+++ b/operator/src/network/testdata/ceramic_ss_weighted_8
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {

--- a/operator/src/network/testdata/ceramic_ss_weighted_9
+++ b/operator/src/network/testdata/ceramic_ss_weighted_9
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {

--- a/operator/src/network/testdata/default_stubs/ceramic_stateful_set
+++ b/operator/src/network/testdata/default_stubs/ceramic_stateful_set
@@ -104,7 +104,7 @@ Request {
                     }
                   }
                 ],
-                "image": "ceramicnetwork/composedb:latest",
+                "image": "ceramicnetwork/composedb:develop",
                 "imagePullPolicy": "Always",
                 "livenessProbe": {
                   "httpGet": {


### PR DESCRIPTION
This aligns all the default versions of the software we set up in Keramik: `ceramic-one:latest` / `js-ceramic:develop` / `composedb:develop` / `ceramic-anchor-service:develop`.

Our tests will usually specify explicit versions of the software being tested.

Thanks for bringing this up, @samika98.